### PR TITLE
Fixed issue #490

### DIFF
--- a/src/rufus.c
+++ b/src/rufus.c
@@ -687,7 +687,11 @@ static BOOL PopulateProperties(int ComboIndex)
 			SetWindowTextU(hLabel, DriveLabel.String[ComboIndex]);
 		}
 	} else {
-		SetWindowTextU(hLabel, img_report.label);
+		if (IsChecked(IDC_BOOT)) {
+			SetWindowTextU(hLabel, img_report.label);
+		} else {
+			SetWindowTextU(hLabel, DriveLabel.String[ComboIndex]);
+		}
 	}
 
 	return TRUE;


### PR DESCRIPTION
Issue #490

Basically just checked to see if the bootable checkbox was checked when populating UI, if it isn't it just sets the volume label textbox to the current volume label.
