### PR TITLE
fix V773 from PVS-Studio

### DIFF
--- a/src/stdfn.c
+++ b/src/stdfn.c
@@ -634,8 +634,10 @@ BOOL IsFontAvailable(const char* font_name) {
 	LOGFONTA lf = { 0 };
 	HDC hDC = GetDC(hMainDialog);
 
-	if (font_name == NULL)
+	if (font_name == NULL) {
+		ReleaseDC(hMainDialog, hDC);
 		return FALSE;
+	}
 
 	lf.lfCharSet = DEFAULT_CHARSET;
 	safe_strcpy(lf.lfFaceName, LF_FACESIZE, font_name);


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio. Warning: [V773](https://www.viva64.com/en/w/v773/) The function was exited without releasing the 'hDC' handle. A resource leak is possible.

(https://github.com/pbatard/rufus/blob/master/src/stdfn.c#L638)
