### PR TITLE
[iso] Support XP/Server 2003 x64 ISOs

### DIFF
--- a/src/iso.c
+++ b/src/iso.c
@@ -84,7 +84,7 @@ static const char* grub_dirname = "/boot/grub/i386-pc";
 static const char* grub_cfg = "grub.cfg";
 static const char* syslinux_cfg[] = { "isolinux.cfg", "syslinux.cfg", "extlinux.conf" };
 static const char* isolinux_bin[] = { "isolinux.bin", "boot.bin" };
-static const char* pe_dirname[] = { "/i386", "/minint" };
+static const char* pe_dirname[] = { "/i386", "/amd64", "/minint" };
 static const char* pe_file[] = { "ntdetect.com", "setupldr.bin", "txtsetup.sif" };
 static const char* reactos_name = "setupldr.sys"; // TODO: freeldr.sys doesn't seem to work
 static const char* kolibri_name = "kolibri.img";
@@ -222,7 +222,7 @@ static BOOL check_iso_props(const char* psz_dirname, int64_t file_length, const 
 					static_sprintf(img_report.install_wim_path, "?:\\%s\\%s", &install_wim_path[1], install_wim_name[i]);
 		}
 
-		// Check for PE (XP) specific files in "/i386" or "/minint"
+		// Check for PE (XP) specific files in "/i386", "/amd64" or "/minint"
 		for (i=0; i<ARRAYSIZE(pe_dirname); i++)
 			if (safe_stricmp(psz_dirname, pe_dirname[i]) == 0)
 				for (j=0; j<ARRAYSIZE(pe_file); j++)
@@ -664,7 +664,7 @@ BOOL ExtractISO(const char* src_iso, const char* dest_dir, BOOL scan)
 	udf_dirent_t* p_udf_root;
 	char *tmp, *buf, *ext;
 	char path[MAX_PATH], path2[16];
-	const char* basedir[] = { "i386", "minint" };
+	const char* basedir[] = { "i386", "amd64", "minint" };
 	const char* tmp_sif = ".\\txtsetup.sif~";
 	iso_extension_mask_t iso_extension_mask = ISO_EXTENSION_ALL;
 	char* spacing = "  ";
@@ -859,7 +859,7 @@ out:
 			// during scan, to see if /minint was provided for OsLoadOptions, as it decides
 			// whether we should use 0x80 or 0x81 as the disk ID in the MBR
 			static_sprintf(path, "/%s/txtsetup.sif",
-				basedir[((img_report.winpe&WINPE_I386) == WINPE_I386)?0:1]);
+				basedir[((img_report.winpe&WINPE_I386) == WINPE_I386)?0:((img_report.winpe&WINPE_AMD64) == WINPE_AMD64?1:2)]);
 			ExtractISOFile(src_iso, path, tmp_sif, FILE_ATTRIBUTE_NORMAL);
 			tmp = get_token_data_file("OsLoadOptions", tmp_sif);
 			if (tmp != NULL) {

--- a/src/rufus.h
+++ b/src/rufus.h
@@ -254,8 +254,9 @@ enum checksum_type {
 #define OLD_C32_THRESHOLD   { 53500, 148000 }
 
 /* ISO details that the application may want */
-#define WINPE_MININT        0x2A
-#define WINPE_I386          0x15
+#define WINPE_MININT        0x124
+#define WINPE_I386          0x49
+#define WINPE_AMD64         0x89
 #define MAX_WIM_VERSION     0x000E0000
 #define HAS_KOLIBRIOS(r)    (r.has_kolibrios)
 #define HAS_REACTOS(r)      (r.reactos_path[0] != 0)
@@ -263,7 +264,7 @@ enum checksum_type {
 #define HAS_SYSLINUX(r)     (r.sl_version != 0)
 #define HAS_BOOTMGR(r)      (r.has_bootmgr)
 #define HAS_INSTALL_WIM(r)  (r.install_wim_path[0] != 0)
-#define HAS_WINPE(r)        (((r.winpe & WINPE_MININT) == WINPE_MININT)||((r.winpe & WINPE_I386) == WINPE_I386))
+#define HAS_WINPE(r)        (((r.winpe & WINPE_MININT) == WINPE_MININT)||((r.winpe & WINPE_I386) == WINPE_I386)||((r.winpe & WINPE_AMD64) == WINPE_AMD64))
 #define HAS_WINDOWS(r)      (HAS_BOOTMGR(r) || (r.uses_minint) || HAS_WINPE(r))
 #define HAS_WIN7_EFI(r)     ((r.has_efi == 1) && HAS_INSTALL_WIM(r))
 #define HAS_EFI_IMG(r)      (r.efi_img_path[0] != 0)
@@ -286,7 +287,7 @@ typedef struct {
 	uint32_t install_wim_version;
 	BOOLEAN is_iso;
 	BOOLEAN is_bootable_img;
-	uint8_t winpe;
+	uint16_t winpe;
 	uint8_t has_efi;
 	BOOLEAN has_4GB_file;
 	BOOLEAN has_long_filename;


### PR DESCRIPTION
First of all, thanks for all the work you've put into Rufus. I've been using Rufus for years now and it's a been a breath of relief compared to the dark ages of things that came before it (I had many in-head acronyms for HPUSBFW, but the 'F' always stood for the same thing). So, apologies in advance for the fact that this PR probably made you groan as soon as you read the title, but... here it comes anyway.

Because of reasons, I needed to install a copy of XP x64 on an older machine yesterday. It also happened that the only DVD drive in my house (which I normally would have used, since XP's boot loader is not known for its USB-friendliness to begin with) was broken. So I fired up Rufus, and saw this for the first time in my life:

![wtf](https://i.imgur.com/dOH4pa0.png)

Even more amazingly, it turns out someone else had this same issue once (#296), although admittedly, that was over 4 years ago, and even then they were told to either fix it themselves or use a supported OS. The FAQ is also pretty clear w.r.t. XP support. So I'm mostly submitting this because I was going to write the patch regardless (I really have no choice in target OS for this machine) and if it gets merged and helps the other 3 people on this planet who use XP x64 for some reason - great. If not, that's fine too.

Some notes on this patch:
- The boot process of an x64 CD of XP/Server 2003 is very similar to Server 2003 x86 since they use the same 32 bit setup (by same I mean bitwise identical). Therefore most of the files relevant for Rufus are still under `\i386`, except for `txtsetup.sif` which is under `\amd64`. `setupldr.bin` must also be patched to use `\amd64` paths rather than `\i386` ones.
- The `winpe` field of `RUFUS_IMG_REPORT` has been widened to 2 bytes since there are now 3 base directories that may exist on a WinPE 1.x disk (`\i386`, `\amd64` and `\minint`) making the maximum possible flag value `>1` byte. This could probably be improved if needed since there are still really only `3^3` relevant files at most.
- `WINPE_MININT` is still mutually exclusive with `WINPE_I386` as well as the new `WINPE_AMD64`, but this is not true for `(WINPE_I386 & WINPE_AMD64)` which gives the nonzero `0x9`. Therefore these two flags should always be tested with a strict equality operator if the distinction is important.