### PR TITLE
ASN.1 parser's sequence tag is wrong

### DIFF
--- a/src/parser.c
+++ b/src/parser.c
@@ -1276,7 +1276,7 @@ static BOOL get_data_from_asn1_internal(const uint8_t* buf, size_t buf_len, cons
 	BOOL is_sequence, is_universal_tag;
 
 	while (pos < buf_len) {
-		is_sequence = buf[pos] & 0x20;
+		is_sequence = buf[pos] & 0x30;
 		is_universal_tag = ((buf[pos] & 0xC0) == 0x00);
 		tag = buf[pos++] & 0x1F;
 		if (tag == 0x1F) {


### PR DESCRIPTION
- Sequence is encoded with tag byte of 0x30.
- https://docs.microsoft.com/en-us/windows/win32/seccertenroll/about-sequence