### PR TITLE
Add User Specified default for --gui command line option

### DIFF
--- a/src/rufus.c
+++ b/src/rufus.c
@@ -2873,7 +2873,8 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
 	int wait_for_mutex = 0;
 	FILE* fd;
 	BOOL attached_console = FALSE, external_loc_file = FALSE, lgp_set = FALSE, automount = TRUE;
-	BOOL disable_hogger = FALSE, previous_enable_HDDs = FALSE, vc = IsRegistryNode(REGKEY_HKCU, vs_reg);
+	BOOL disable_hogger = SHRegGetBoolUSValueA("SOFTWARE\\" COMPANY_NAME "\\" APPLICATION_NAME, "gui", /*fIgnoreHKCU*/ FALSE, /*fDefault*/ FALSE);
+	BOOL previous_enable_HDDs = FALSE, vc = IsRegistryNode(REGKEY_HKCU, vs_reg);
 	BOOL alt_pressed = FALSE, alt_command = FALSE;
 	BYTE *loc_data;
 	DWORD loc_size, u, size = sizeof(u);
@@ -2944,7 +2945,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
 				// processing arguments with getopt, as we may want to print messages
 				// on the commandline then, which the hogger makes more intuitive.
 				if ((strcmp(argv[i], "-g") == 0) || (strcmp(argv[i], "--gui") == 0))
-					disable_hogger = TRUE;
+					disable_hogger ^= TRUE;
 			}
 			// If our application name contains a 'p' (for "portable") create a 'rufus.ini'
 			// NB: argv[0] is populated in the previous loop


### PR DESCRIPTION
@pbatard 
I would like to be able to persist my desire to run with the --gui command line option enabled most of the time. Without having to run a custom version of rufus (built from source). This change should be minimally disruptive (it modifies 2 lines and adds one). It maintains the current behavior in all "normal" situations. 

## Considerations
I originally intended to use the rufus specific ReadSettingBool() function, but I didn't for two reasons: one is that this is read so early that the ini file has not been initialized yet so it would always read from the registry; two is that if the key does not exist in the registry it would be written even when running the portable version of rufus. This leaves me using a SHLWAPI function "bare". The good news is that it is read only. The bad news is that it will also look from the key under HKLM as well as HKCU.

Also I originally was hoping to use --no-gui and -g- to turn this feature back off. Unfortunately the C version of getopt_long does not support this feature (other language implementations like ruby and node seem to) also this does not work since -g is pre-processed anyway. Therefore I chose to make -g be a toggle. This has minimal impact on code size but may be seen as counter-intuitive.

## Code size
My test of the x86 release build saw no change in size. However it does not appear that the .sln file applies UPX, and the default code alignment is 4K I think; so not too surprising. 

If you are willing to except this ER but wish to have these concerns addressed in a different way I will be happy to try again.