### PR TITLE
[core] Only retry writes when they fail

### DIFF
--- a/src/format.c
+++ b/src/format.c
@@ -726,7 +726,7 @@ static BOOL ClearMBRGPT(HANDLE hPhysicalDrive, LONGLONG DiskSize, DWORD SectorSi
 				uprintf("Retrying in %d seconds...", WRITE_TIMEOUT / 1000);
 				// Don't sit idly but use the downtime to check for conflicting processes...
 				Sleep(CheckDriveAccess(WRITE_TIMEOUT, FALSE));
-			}
+			} else break;
 		}
 	}
 	for (i = last_sector - MAX_SECTORS_TO_CLEAR; i < last_sector; i++) {
@@ -743,7 +743,7 @@ static BOOL ClearMBRGPT(HANDLE hPhysicalDrive, LONGLONG DiskSize, DWORD SectorSi
 					r = TRUE;
 					goto out;
 				}
-			}
+			} else break;
 		}
 	}
 	r = TRUE;


### PR DESCRIPTION
ClearMBRGPT attempts to write WRITE_RETRIES times, even if all those
times succeed.

Instead, skip the remaining retries on success.