### PR TITLE
fix vs2019 C2001

### DIFF
--- a/.vs/ext2fs.vcxproj
+++ b/.vs/ext2fs.vcxproj
@@ -324,6 +324,7 @@
       <AdditionalIncludeDirectories>..\src;..\src\msvc-missing</AdditionalIncludeDirectories>
       <CompileAs>CompileAsC</CompileAs>
       <DisableSpecificWarnings>4018;4146;4244;4267;4996</DisableSpecificWarnings>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SuppressStartupBanner>true</SuppressStartupBanner>


### PR DESCRIPTION
`rufus.h(52,1): error C2001` while compiling “ext2fs”