### PR TITLE
Cope with UTF-8 codepage

### DIFF
--- a/src/dos_locale.c
+++ b/src/dos_locale.c
@@ -419,7 +419,8 @@ static cp_list cp_hr_list[] = {
 	{ 59829, "Georgian"},
 	{ 60258, "Lat-Azeri"},
 	{ 60853, "Georgian (Alt)"},
-	{ 62306, "Cyr-Uzbek"}
+	{ 62306, "Cyr-Uzbek"},
+	{ 65001, "Unicode (UTF-8)"}
 };
 
 static const char* cp_to_hr(ULONG cp)


### PR DESCRIPTION
Add UTF-8 codepage 65001, sometimes referred to as "Unicode (UTF-8 without signature)". Recent versions of Windows allow for locale variants with UTF-8 encoding, making `CP_UTF8` a valid return for `GetOEMCP()`. Alternatively, you could drop `cp_hr_list` and instead call  [GetCPInfoExA](https://docs.microsoft.com/en-us/windows/win32/api/winnls/nf-winnls-getcpinfoexa).