### PR TITLE
Add http2, gzip, deflate support

### DIFF
--- a/src/missing.h
+++ b/src/missing.h
@@ -109,6 +109,15 @@ static __inline void *_reallocf(void *ptr, size_t size) {
 #ifndef WM_COPYGLOBALDATA
 #define WM_COPYGLOBALDATA 0x49
 #endif
+#ifndef INTERNET_OPTION_ENABLE_HTTP_PROTOCOL
+#define INTERNET_OPTION_ENABLE_HTTP_PROTOCOL 148
+#endif
+#ifndef INTERNET_OPTION_HTTP_DECODING
+#define INTERNET_OPTION_HTTP_DECODING 65
+#endif
+#ifndef HTTP_PROTOCOL_FLAG_HTTP2
+#define HTTP_PROTOCOL_FLAG_HTTP2 0x2
+#endif
 
 /* The following is used for native ISO mounting in Windows 8 or later */
 #define VIRTUAL_STORAGE_TYPE_VENDOR_MICROSOFT \

--- a/src/net.c
+++ b/src/net.c
@@ -54,6 +54,7 @@ extern HANDLE dialog_handle;
 extern BOOL is_x86_32, close_fido_cookie_prompts;
 static DWORD error_code, fido_len = 0;
 static BOOL force_update_check = FALSE;
+static const char* request_headers = "Accept-Encoding: gzip, deflate";
 
 /*
  * FormatMessage does not handle internet errors
@@ -265,7 +266,7 @@ static HINTERNET GetInternetSession(BOOL bRetry)
 	int i;
 	char agent[64];
 	BOOL r, decodingSupport = TRUE;
-	DWORD dwFlags, dwTimeout = NET_SESSION_TIMEOUT, protocalSupport = HTTP_PROTOCOL_FLAG_HTTP2;
+	DWORD dwFlags, dwTimeout = NET_SESSION_TIMEOUT, dwProtocolSupport = HTTP_PROTOCOL_FLAG_HTTP2;
 	HINTERNET hSession = NULL;
 
 	PF_TYPE_DECL(WINAPI, BOOL, InternetGetConnectedState, (LPDWORD, DWORD));
@@ -298,7 +299,7 @@ static HINTERNET GetInternetSession(BOOL bRetry)
 	// Enable gzip and deflate decoding schemes
 	pfInternetSetOptionA(hSession, INTERNET_OPTION_HTTP_DECODING, (LPVOID)&decodingSupport, sizeof(decodingSupport));
 	// Enable HTTP/2 protocol support
-	pfInternetSetOptionA(hSession, INTERNET_OPTION_ENABLE_HTTP_PROTOCOL, (LPVOID)&protocalSupport, sizeof(protocalSupport));
+	pfInternetSetOptionA(hSession, INTERNET_OPTION_ENABLE_HTTP_PROTOCOL, (LPVOID)&dwProtocolSupport, sizeof(dwProtocolSupport));
 
 out:
 	return hSession;
@@ -388,7 +389,7 @@ uint64_t DownloadToFileOrBuffer(const char* url, const char* file, BYTE** buffer
 		goto out;
 	}
 
-	if (!pfHttpSendRequestA(hRequest, "Accept-Encoding: gzip, deflate", -1L, NULL, 0)) {
+	if (!pfHttpSendRequestA(hRequest, request_headers, -1L, NULL, 0)) {
 		uprintf("Unable to send request: %s", WinInetErrorString());
 		goto out;
 	}
@@ -731,7 +732,7 @@ static DWORD WINAPI CheckForUpdatesThread(LPVOID param)
 				INTERNET_FLAG_IGNORE_REDIRECT_TO_HTTP|INTERNET_FLAG_IGNORE_REDIRECT_TO_HTTPS|
 				INTERNET_FLAG_NO_COOKIES|INTERNET_FLAG_NO_UI|INTERNET_FLAG_NO_CACHE_WRITE|INTERNET_FLAG_HYPERLINK|
 				((UrlParts.nScheme == INTERNET_SCHEME_HTTPS)?INTERNET_FLAG_SECURE:0), (DWORD_PTR)NULL);
-			if ((hRequest == NULL) || (!pfHttpSendRequestA(hRequest, "Accept-Encoding: gzip, deflate", -1L, NULL, 0))) {
+			if ((hRequest == NULL) || (!pfHttpSendRequestA(hRequest, request_headers, -1L, NULL, 0))) {
 				uprintf("Unable to send request: %s", WinInetErrorString());
 				goto out;
 			}
@@ -1095,7 +1096,7 @@ BOOL IsDownloadable(const char* url)
 	if (hRequest == NULL)
 		goto out;
 
-	if (!pfHttpSendRequestA(hRequest, "Accept-Encoding: gzip, deflate", -1L, NULL, 0))
+	if (!pfHttpSendRequestA(hRequest, request_headers, -1L, NULL, 0))
 		goto out;
 
 	// Get the file size


### PR DESCRIPTION
This PR enables support for the http/2 protocol and enables automatic gzip/deflate decoding support. 

These options are backwards compatible and are only used when the server supports these features.