### PR TITLE
Added bypass for cpu model and storage space check

### DIFF
--- a/src/format.c
+++ b/src/format.c
@@ -1442,7 +1442,7 @@ BOOL RemoveWindows11Restrictions(char drive_letter)
 	int i;
 	const int wim_index = 2;
 	const char* offline_hive_name = "RUFUS_OFFLINE_HIVE";
-	const char* key_name[] = { "BypassTPMCheck", "BypassSecureBootCheck", "BypassRAMCheck" };
+	const char* key_name[] = { "BypassTPMCheck", "BypassSecureBootCheck", "BypassRAMCheck", "BypassCPUCheck", "BypassStorageCheck" };
 	char boot_wim_path[] = "#:\\sources\\boot.wim", key_path[64];
 	char* mount_path = NULL;
 	char path[MAX_PATH];


### PR DESCRIPTION
This allows older unsupported machines with less than 64GB of storage (Windows 11 takes around 15 stock) and a CPU before 6th gen intel/2nd gen Ryzen to be able to run Windows 11.
I'm assuming there are more changes that need to be made, but there were no clear contribution guidelines I could find so feel free to add what's missing or tell me what I have to add.