### PR TITLE
Typos found by codespell

### DIFF
--- a/res/loc/pollock/Pollock.cs
+++ b/res/loc/pollock/Pollock.cs
@@ -234,7 +234,7 @@ namespace pollock
                             lang.lcid += " " + parts[i];
                         break;
                     case 'a':
-                        // This attribue will be restored manually
+                        // This attribute will be restored manually
                         break;
                     case 'g':
                         comment = null;
@@ -300,7 +300,7 @@ namespace pollock
         /// <summary>
         /// Create .po/.pot files from a list of Language elements.
         /// </summary>
-        /// <param name="langs">A lits of Language objects to process.</param>
+        /// <param name="langs">A list of Language objects to process.</param>
         /// <param name="old_en_US">(Optional) A previous version of en-US to use for comparison.</param>
         /// <param name="path">(Optional) The path where the .po/.pot files should be created.</param>
         /// <returns>The number of PO files created.</returns>
@@ -457,7 +457,7 @@ namespace pollock
             bool is_pot = file.EndsWith(".pot");
             bool file_locked = true;
             string[] lines = null;
-            // May get an I/O expection if Poedit is not done
+            // May get an I/O exception if Poedit is not done
             do
             {
                 try
@@ -924,7 +924,7 @@ namespace pollock
             // Fix needed for Windows 7 to download from github SSL
             ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-            // Also set the Console width to something that can accomodate us
+            // Also set the Console width to something that can accommodate us
             if (Console.WindowWidth < 100)
                 Console.SetWindowSize(100, Console.WindowHeight);
 

--- a/src/checksum.c
+++ b/src/checksum.c
@@ -1343,7 +1343,7 @@ const char* test_hash[CHECKSUM_MAX][4] = {
 	},
 };
 
-/* Tests the message digest aglorithms */
+/* Tests the message digest algorithms */
 int TestChecksum(void)
 {
 	const uint32_t blocksize[CHECKSUM_MAX] = { MD5_BLOCKSIZE, SHA1_BLOCKSIZE, SHA256_BLOCKSIZE, SHA512_BLOCKSIZE };

--- a/src/dos_locale.c
+++ b/src/dos_locale.c
@@ -42,7 +42,7 @@
  */
 
 /* WinME DOS keyboard 2 letter codes & supported keyboard ID(s), as retrieved
- * from the Millenium disk image in diskcopy.dll on a Windows 7 system
+ * from the Millennium disk image in diskcopy.dll on a Windows 7 system
  *
  *	KEYBOARD.SYS
  *		GR 129*

--- a/src/drive.c
+++ b/src/drive.c
@@ -360,7 +360,7 @@ char* GetLogicalName(DWORD DriveIndex, uint64_t PartitionOffset, BOOL bKeepTrail
 	if (i < found_name.Index) {
 		ret = safe_strdup(found_name.String[i]);
 	} else {
-		// NB: We need to re-add DRIVE_INDEX_MIN for this call since CheckDriveIndex() substracted it
+		// NB: We need to re-add DRIVE_INDEX_MIN for this call since CheckDriveIndex() subtracted it
 		ret = AltGetLogicalName(DriveIndex + DRIVE_INDEX_MIN, PartitionOffset, bKeepTrailingBackslash, bSilent);
 		if ((ret != NULL) && (strchr(ret, ' ') != NULL))
 			uprintf("Warning: Using physical device to access partition data");
@@ -829,7 +829,7 @@ BOOL DeletePartition(DWORD DriveIndex, ULONGLONG PartitionOffset, BOOL bSilent)
 }
 
 /*
- * Count on Microsoft for *COMPLETELY CRIPPLING* an API when alledgedly upgrading it...
+ * Count on Microsoft for *COMPLETELY CRIPPLING* an API when allegedly upgrading it...
  * As illustrated when you do so with diskpart (which uses VDS behind the scenes), VDS
  * simply *DOES NOT* list all the volumes that the system can see, especially compared
  * to what mountvol (which uses FindFirstVolume()/FindNextVolume()) and other APIs do.
@@ -1609,7 +1609,7 @@ BOOL ToggleEsp(DWORD DriveIndex, uint64_t PartitionOffset)
 			// We successfully reverted ESP from Basic Data -> Delete stored ESP info
 			ClearEspInfo((uint8_t)j);
 		} else if (!IsDriveLetterInUse(*mount_point)) {
-			// We succesfully switched ESP to Basic Data -> Try to mount it
+			// We successfully switched ESP to Basic Data -> Try to mount it
 			volume_name = GetLogicalName(DriveIndex, DriveLayout->PartitionEntry[i].StartingOffset.QuadPart, TRUE, FALSE);
 			IGNORE_RETVAL(MountVolume(mount_point, volume_name));
 			free(volume_name);

--- a/src/format.c
+++ b/src/format.c
@@ -1246,7 +1246,7 @@ int SetWinToGoIndex(void)
 			wininst_index = 0;
 	}
 
-	// If we're not using a straigth install.wim, we need to mount the ISO to access it
+	// If we're not using a straight install.wim, we need to mount the ISO to access it
 	if (!img_report.is_windows_img) {
 		mounted_iso = MountISO(image_path);
 		if (mounted_iso == NULL) {

--- a/src/format_ext.c
+++ b/src/format_ext.c
@@ -313,7 +313,7 @@ BOOL FormatExtFs(DWORD DriveIndex, uint64_t PartitionOffset, DWORD BlockSize, LP
 	features.s_log_cluster_size = features.s_log_block_size;
 	size /= BlockSize;
 
-	// ext2 and ext3 have a can only accomodate up to Blocksize * 2^32 sized volumes
+	// ext2 and ext3 have a can only accommodate up to Blocksize * 2^32 sized volumes
 	if (((strcmp(FSName, FileSystemLabel[FS_EXT2]) == 0) || (strcmp(FSName, FileSystemLabel[FS_EXT3]) == 0)) &&
 		(size >= 0x100000000ULL)) {
 		SET_EXT2_FORMAT_ERROR(ERROR_INVALID_VOLUME_SIZE);

--- a/src/format_fat32.c
+++ b/src/format_fat32.c
@@ -356,7 +356,7 @@ BOOL FormatLargeFAT32(DWORD DriveIndex, uint64_t PartitionOffset, DWORD ClusterS
 	// Sector 6 Backup boot sector
 	// Sector 7 Backup FSInfo sector
 	// Sector 8 Backup 'more boot code'
-	// zeroed sectors upto ReservedSectCount
+	// zeroed sectors up to ReservedSectCount
 	// FAT1  ReservedSectCount to ReservedSectCount + FatSize
 	// ...
 	// FATn  ReservedSectCount to ReservedSectCount + FatSize

--- a/src/iso.c
+++ b/src/iso.c
@@ -1437,7 +1437,7 @@ BOOL HasEfiImgBootLoaders(void)
 	p_private->p_iso = p_iso;
 	p_private->lsn = p_statbuf->lsn;
 	p_private->sec_start = 0;
-	// Populate our intial buffer
+	// Populate our initial buffer
 	if (iso9660_iso_seek_read(p_private->p_iso, p_private->buf, p_private->lsn, ISO_NB_BLOCKS) != ISO_NB_BLOCKS * ISO_BLOCKSIZE) {
 		uprintf("Error reading ISO-9660 file %s at LSN %lu\n", img_report.efi_img_path, (long unsigned int)p_private->lsn);
 		goto out;
@@ -1528,7 +1528,7 @@ BOOL DumpFatDir(const char* path, int32_t cluster)
 		p_private->p_iso = p_iso;
 		p_private->lsn = p_statbuf->lsn;
 		p_private->sec_start = 0;
-		// Populate our intial buffer
+		// Populate our initial buffer
 		if (iso9660_iso_seek_read(p_private->p_iso, p_private->buf, p_private->lsn, ISO_NB_BLOCKS) != ISO_NB_BLOCKS * ISO_BLOCKSIZE) {
 			uprintf("Error reading ISO-9660 file %s at LSN %lu\n", img_report.efi_img_path, (long unsigned int)p_private->lsn);
 			goto out;

--- a/src/net.c
+++ b/src/net.c
@@ -319,7 +319,7 @@ out:
  * to the dialog in question, with WPARAM being set to nonzero for EXIT on success
  * and also attempt to indicate progress using an IDC_PROGRESS control
  * Note that when a buffer is used, the actual size of the buffer is one more than its reported
- * size (with the extra byte set to 0) to accomodate for calls that need a NUL-terminated buffer.
+ * size (with the extra byte set to 0) to accommodate for calls that need a NUL-terminated buffer.
  */
 uint64_t DownloadToFileOrBuffer(const char* url, const char* file, BYTE** buffer, HWND hProgressDialog, BOOL bTaskBarProgress)
 {

--- a/src/parser.c
+++ b/src/parser.c
@@ -1217,7 +1217,7 @@ char* replace_in_token_data(const char* filename, const char* token, const char*
 			// coverity[invalid_type]
 			fwprintf_s(fd_out, L"%s%s", &buf[p[j]], wrep);
 
-		// Ouput the last fragment
+		// Output the last fragment
 		// coverity[invalid_type]
 		fwprintf_s(fd_out, L"%s", &buf[p[j]]);
 

--- a/src/process.c
+++ b/src/process.c
@@ -650,7 +650,7 @@ out:
  * \param bIgnoreSelf Whether the current process should be listed.
  * \param bQuiet Prints minimal output.
  *
- * \return a byte containing the cummulated access rights (f----xwr) from all the handles found
+ * \return a byte containing the cumulated access rights (f----xwr) from all the handles found
  *         with bit 7 ('f') also set if at least one process was found.
  */
 BYTE SearchProcess(char* HandleName, DWORD dwTimeOut, BOOL bPartialMatch, BOOL bIgnoreSelf, BOOL bQuiet)

--- a/src/rufus.c
+++ b/src/rufus.c
@@ -1006,7 +1006,7 @@ BOOL CALLBACK LogCallback(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam)
 			ShowWindow(hDlg, SW_HIDE);
 			log_displayed = FALSE;
 			// Set focus to the Cancel button on the main dialog
-			// This avoids intempestive tooltip display from the log toolbar buttom
+			// This avoids intempestive tooltip display from the log toolbar button
 			SendMessage(hMainDialog, WM_NEXTDLGCTL, (WPARAM)GetDlgItem(hMainDialog, IDCANCEL), TRUE);
 			return TRUE;
 		case IDC_LOG_CLEAR:
@@ -1036,7 +1036,7 @@ BOOL CALLBACK LogCallback(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam)
 		reset_localization(IDD_LOG);
 		log_displayed = FALSE;
 		// Set focus to the Cancel button on the main dialog
-		// This avoids intempestive tooltip display from the log toolbar buttom
+		// This avoids intempestive tooltip display from the log toolbar button
 		SendMessage(hMainDialog, WM_NEXTDLGCTL, (WPARAM)GetDlgItem(hMainDialog, IDCANCEL), TRUE);
 		return TRUE;
 	case UM_RESIZE_BUTTONS:
@@ -3972,7 +3972,7 @@ relaunch:
 		}
 
 		// Standalone 'Alt' key toggles progress report between percent, rate (if available)
-		// and remaining time (if availabe)
+		// and remaining time (if available)
 		if (alt_pressed && !(GetKeyState(VK_MENU) & 0x8000)) {
 			alt_pressed = FALSE;
 			if (!alt_command)

--- a/src/rufus.h
+++ b/src/rufus.h
@@ -106,7 +106,7 @@
 #define UDF_FORMAT_SPEED            3.1f		// Speed estimate at which we expect UDF drives to be formatted (GB/s)
 #define UDF_FORMAT_WARN             20			// Duration (in seconds) above which we warn about long UDF formatting times
 #define MAX_FAT32_SIZE              2.0f		// Threshold above which we disable FAT32 formatting (in TB)
-#define FAT32_CLUSTER_THRESHOLD     1.011f		// For FAT32, cluster size changes don't occur at power of 2 boundaries but sligthly above
+#define FAT32_CLUSTER_THRESHOLD     1.011f		// For FAT32, cluster size changes don't occur at power of 2 boundaries but slightly above
 #define DD_BUFFER_SIZE              (32 * 1024 * 1024)	// Minimum size of buffer to use for DD operations
 #define UBUFFER_SIZE                4096
 #define RSA_SIGNATURE_SIZE          256

--- a/src/syslinux.c
+++ b/src/syslinux.c
@@ -290,7 +290,7 @@ BOOL InstallSyslinux(DWORD drive_index, char drive_letter, int file_system)
 	/* Patch ldlinux.sys and the boot sector */
 	if (syslinux_patch(sectors, nsectors, 0, 0, NULL, NULL) < 0) {
 		uprintf("Could not patch Syslinux files.");
-		uprintf("WARNING: This could be caused by your firewall having modifed downloaded content, such as 'ldlinux.sys'...");
+		uprintf("WARNING: This could be caused by your firewall having modified downloaded content, such as 'ldlinux.sys'...");
 		goto out;
 	}
 

--- a/src/ui.c
+++ b/src/ui.c
@@ -784,7 +784,7 @@ void ToggleImageOptions(void)
 
 	assert(popcnt8(image_options) <= 1);
 
-	// Keep a copy of the "Image Option" text (so that we don't have to duplicate its transation in the .loc)
+	// Keep a copy of the "Image Option" text (so that we don't have to duplicate its translation in the .loc)
 	if (image_option_txt[0] == 0)
 		GetWindowTextU(GetDlgItem(hMainDialog, IDS_IMAGE_OPTION_TXT), image_option_txt, sizeof(image_option_txt));
 


### PR DESCRIPTION
I have left out 3rd party software.

Most changes are in code comments, but at least a user-visible string has been fixed.