### PR TITLE
Add MIRACLE LINUX 8 to the list of RHEL8 derivatives

### DIFF
--- a/src/rufus.c
+++ b/src/rufus.c
@@ -1267,6 +1267,7 @@ DWORD WINAPI ImageScanThread(LPVOID param)
 		"^OL-8.*",				// Oracle Linux 8.x
 		"^RHEL-8.*",			// Red Hat 8.x
 		"^Rocky-8.*",			// Rocky Linux 8.x
+		"^MIRACLE-LINUX-8-.*",		// MIRACLE LINUX 8.x
 	};
 	int i, len;
 	uint8_t arch;


### PR DESCRIPTION
MIRACLE LINUX is a Red Hat derivative, so it needs the same special
treatment as Red Hat, CentOS, etc to work around issues in anaconda.

This commit adds MIRACLE LINUX to the list of Red Hat derivatives.

I have verified that rufus compiles correctly and that the generated USB 
drive can be installed from. The compilation log and rufus's log are attached.

[buildlog.txt](https://github.com/pbatard/rufus/files/8029376/buildlog.txt)
[rufus.log](https://github.com/pbatard/rufus/files/8029378/rufus.log)

Below is the primary volume descriptor from the ML8.4 ISO image. 

===== BEGIN ML8.4 primary volume descriptor =====
CD-ROM is in ISO 9660 format
System id: LINUX
Volume id: MIRACLE-LINUX-8-4-x86_64
Volume set id:
Publisher id:
Data preparer id:
Application id: GENISOIMAGE ISO 9660/HFS FILESYSTEM CREATOR (C) 1993 E.YOUNGDALE (C) 1997-2006 J.PEARSON/J.SCHILLING (C) 2006-2007 CDRKIT TEAM
Copyright File id:
Abstract File id:
Bibliographic File id:
Volume set size is: 1
Volume set sequence number is: 1
Logical block size is: 2048
Volume size is: 4900572
El Torito VD version 1 found, boot catalog is in sector 1155
Joliet with UCS level 3 found
Rock Ridge signatures version 1 found
Eltorito validation header:
    Hid 1
    Arch 0 (x86)
    ID ''
    Key 55 AA
    Eltorito defaultboot header:
        Bootid 88 (bootable)
        Boot media 0 (No Emulation Boot)
        Load segment 0
        Sys type 0
        Nsect 4
        Bootoff 54D67 347495
===== END ML8.4 primary volume descriptor =====