### PR TITLE
Use strtoull instead of atoll

### DIFF
--- a/src/net.c
+++ b/src/net.c
@@ -428,7 +428,7 @@ uint64_t DownloadToFileOrBuffer(const char* url, const char* file, BYTE** buffer
 		uprintf("Unable to retrieve file length: %s", WinInetErrorString());
 		goto out;
 	}
-	total_size = strtoull(strsize);
+	total_size = strtoull(strsize, NULL, 10);
 	if (hProgressDialog != NULL) {
 		char msg[128];
 		uprintf("File length: %s", SizeToHumanReadable(total_size, FALSE, FALSE));

--- a/src/net.c
+++ b/src/net.c
@@ -428,7 +428,7 @@ uint64_t DownloadToFileOrBuffer(const char* url, const char* file, BYTE** buffer
 		uprintf("Unable to retrieve file length: %s", WinInetErrorString());
 		goto out;
 	}
-	total_size = (uint64_t)atoll(strsize);
+	total_size = strtoull(strsize);
 	if (hProgressDialog != NULL) {
 		char msg[128];
 		uprintf("File length: %s", SizeToHumanReadable(total_size, FALSE, FALSE));

--- a/src/rufus.c
+++ b/src/rufus.c
@@ -2478,7 +2478,7 @@ static INT_PTR CALLBACK MainCallback(HWND hDlg, UINT message, WPARAM wParam, LPA
 					break;
 				}
 				GetWindowTextA(GetDlgItem(hDlg, IDC_PERSISTENCE_SIZE), tmp, sizeof(tmp));
-				lPos = atol(tmp);
+				lPos = strtol(tmp, NULL, 10);
 				persistence_unit_selection = ComboBox_GetCurSel(GetDlgItem(hDlg, IDC_PERSISTENCE_UNITS));
 				persistence_size = lPos * MB;
 				for (i = 0; i < persistence_unit_selection; i++)
@@ -2520,7 +2520,7 @@ static INT_PTR CALLBACK MainCallback(HWND hDlg, UINT message, WPARAM wParam, LPA
 			if (ComboBox_GetCurSel(GetDlgItem(hDlg, IDC_PERSISTENCE_UNITS)) == persistence_unit_selection)
 				break;
 			GetWindowTextA(GetDlgItem(hMainDialog, IDC_PERSISTENCE_SIZE), tmp, sizeof(tmp));
-			persistence_size = atol(tmp) * MB;
+			persistence_size = strtol(tmp, NULL, 10) * MB;
 			for (i = 0; i < persistence_unit_selection; i++)
 				persistence_size *= 1024;
 			persistence_unit_selection = ComboBox_GetCurSel(GetDlgItem(hDlg, IDC_PERSISTENCE_UNITS));


### PR DESCRIPTION
This means we don't need to worry about conversion issues regarding signedess. In addition, the behavior will no longer be undefined if for some reason the conversion cannot happen.