### PR TITLE
Volume label does not a directory anymore

### DIFF
--- a/src/syslinux/libfat/searchdir.c
+++ b/src/syslinux/libfat/searchdir.c
@@ -40,7 +40,8 @@ int32_t libfat_searchdir(struct libfat_filesystem *fs, int32_t dirclust,
 
 	for (nent = 0; nent < LIBFAT_SECTOR_SIZE;
 	     nent += sizeof(struct fat_dirent)) {
-	    if (!memcmp(dep->name, name, 11)) {
+	    // Volume label entry must be ignored: it is not a real directory
+	    if ((dep->attribute & 0x08) == 0 && !memcmp(dep->name, name, 11)) {
 		if (direntry) {
 		    memcpy(direntry->entry, dep, sizeof(*dep));
 		    direntry->sector = s;


### PR DESCRIPTION
Fix issue #2288 

As [wikipedia](https://en.wikipedia.org/wiki/Design_of_the_FAT_file_system#Directory_entry) is written for directory entries, file attribute with value `0x08` is a volume label.

# Rufus log after patch with problematic ISO

```
Rufus x64 v4.2.2072
Windows version: Windows 10 Pro x64 (Build 19045.3208)
Syslinux versions: 4.07/2013-07-25, 6.04/pre1
Grub versions: 0.4.6a, 2.06
System locale ID: 0x0409 (en-US)
Will use default UI locale 0x0409
SetLGP: Successfully set NoDriveTypeAutorun policy to 0x0000009E
Localization set to 'en-US'
Notice: The ISO download feature has been deactivated because 'Check for updates' is disabled in your settings.
Found 517 officially revoked UEFI bootloaders from embedded list
Found 2351 additional revoked UEFI bootloaders from this system's SKUSiPolicy.p7b
Found USB 2.0 device 'JetFlash Transcend 8GB USB Device' (8564:1000)
NOTE: This device is a USB 3.0 device operating at lower speed...
1 device found
Disk type: Removable, Disk size: 7.9GB, Sector size: 512 bytes
Cylinders: 960, Tracks per cylinder: 255, Sectors per track: 63
Partition type: SFD (Super Floppy Disk) or unpartitioned

Image provided: 'D:\Projects\my-iso.iso'
Scanning image...
ISO analysis:
  Image is an ISO9660 image
  Detected EFI bootloader(s) (from '/boot/grub/efiboot.img'):
  ● 'bootx64.efi'
Disk image analysis:
  Image does not have a Boot Marker
ISO label: 'MyIsoImage'
  Size: 497 MB (Projected)
  Uses: EFI
Using image: my-iso.iso (497.4 MB)
```