### PR TITLE
[vhd] allow the use of FreeBSD bhyve virtual disks

### DIFF
--- a/src/dev.c
+++ b/src/dev.c
@@ -287,6 +287,7 @@ static __inline BOOL IsVHD(const char* buffer)
 		"Arsenal_________Virtual_",
 		"KernSafeVirtual_________",
 		"Msft____Virtual_Disk____",
+		"BHYVE__________SATA_DISK",
 		"VMware__VMware_Virtual_S"	// Enabled through a cheat mode, as this lists primary disks on VMWare instances
 	};
 


### PR DESCRIPTION
FreeBSD bhyve virtualization does not allow passthrough of individual USB devices. This change allows the detection of the bhyve virtual device volume similar to how VMware and HyperV is handled.

Verified by @marietto2008 via https://github.com/pbatard/rufus/issues/2500#issuecomment-2166982401 and https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=279659#c11 