### PR TITLE
CMake support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,33 @@
+cmake_minimum_required(VERSION 3.16)
+
+project(rufus C)
+
+if(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE Release)
+endif()
+
+if(CMAKE_BINARY_DIR MATCHES "^${CMAKE_SOURCE_DIR}")
+    message(WARNING "In-source build detected")
+endif()
+
+if(MSVC)
+    add_compile_options(/utf-8)
+endif()
+
+function(add_all_subdirs)
+    file(GLOB children RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *)
+
+    foreach(child ${children})
+        if(NOT IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/${child})
+            continue()
+        endif()
+
+        if(NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${child}/CMakeLists.txt)
+            continue()
+        endif()
+
+        add_subdirectory(${child} ${ARGN})
+    endforeach()
+endfunction()
+
+add_all_subdirs()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,40 @@
+add_all_subdirs()
+set(target_name rufus)
+file(GLOB source_files *.c *.h rufus.rc)
+add_executable(${target_name} WIN32 ${source_files})
+
+target_include_directories(${target_name} PRIVATE
+                           .
+                           msvc-missing
+                           ms-sys/inc
+                           syslinux/libinstaller
+                           syslinux/libfat
+                           syslinux/win
+                           libcdio
+                           getopt)
+
+target_compile_definitions(${target_name} PRIVATE
+                           _OFF_T_DEFINED
+                           _off_t=__int64
+                           off_t=_off_t
+                           COBJMACROS
+                           _CRTDBG_MAP_ALLOC)
+
+target_link_libraries(${target_name} PRIVATE
+                      bled
+                      ext2fs
+                      getopt
+                      libcdio-driver
+                      libcdio-iso9660
+                      libcdio-udf
+                      ms-sys
+                      syslinux-libfat
+                      syslinux-libinstaller
+                      syslinux-win
+                      comctl32
+                      crypt32
+                      dwmapi
+                      setupapi
+                      shlwapi
+                      version
+                      wintrust)

--- a/src/bled/CMakeLists.txt
+++ b/src/bled/CMakeLists.txt
@@ -1,0 +1,11 @@
+set(target_name bled)
+file(GLOB source_files *.c *.h)
+add_library(${target_name} STATIC ${source_files})
+target_include_directories(${target_name} PRIVATE ..)
+
+target_compile_definitions(${target_name} PRIVATE
+                           _OFF_T_DEFINED
+                           _off_t=__int64
+                           off_t=_off_t
+                           _FILE_OFFSET_BITS=64
+                           _CRTDBG_MAP_ALLOC)

--- a/src/ext2fs/CMakeLists.txt
+++ b/src/ext2fs/CMakeLists.txt
@@ -1,0 +1,5 @@
+set(target_name ext2fs)
+file(GLOB source_files *.c *.h)
+add_library(${target_name} STATIC ${source_files})
+target_include_directories(${target_name} PRIVATE .. ../msvc-missing)
+target_compile_definitions(${target_name} PRIVATE _CRT_SECURE_NO_WARNINGS _CRTDBG_MAP_ALLOC)

--- a/src/getopt/CMakeLists.txt
+++ b/src/getopt/CMakeLists.txt
@@ -1,0 +1,4 @@
+set(target_name getopt)
+file(GLOB source_files *.c *.h)
+add_library(${target_name} STATIC ${source_files})
+target_compile_definitions(${target_name} PRIVATE HAVE_STRING_H)

--- a/src/libcdio/CMakeLists.txt
+++ b/src/libcdio/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_all_subdirs()

--- a/src/libcdio/driver/CMakeLists.txt
+++ b/src/libcdio/driver/CMakeLists.txt
@@ -1,0 +1,16 @@
+set(target_name libcdio-driver)
+file(GLOB source_files *.c *.h)
+add_library(${target_name} STATIC ${source_files})
+
+target_include_directories(${target_name} PRIVATE
+                           ${CMAKE_SOURCE_DIR}/src
+                           ${CMAKE_SOURCE_DIR}/src/libcdio
+                           ${CMAKE_SOURCE_DIR}/src/msvc-missing)
+
+target_compile_definitions(${target_name} PRIVATE
+                           HAVE_CONFIG_H
+                           _OFF_T_DEFINED
+                           _off_t=__int64
+                           off_t=_off_t
+                           _FILE_OFFSET_BITS=64
+                           _CRTDBG_MAP_ALLOC)

--- a/src/libcdio/iso9660/CMakeLists.txt
+++ b/src/libcdio/iso9660/CMakeLists.txt
@@ -1,0 +1,17 @@
+set(target_name libcdio-iso9660)
+file(GLOB source_files *.c *.h)
+add_library(${target_name} STATIC ${source_files})
+
+target_include_directories(${target_name} PRIVATE
+                           ${CMAKE_SOURCE_DIR}/src
+                           ${CMAKE_SOURCE_DIR}/src/libcdio
+                           ${CMAKE_SOURCE_DIR}/src/libcdio/driver
+                           ${CMAKE_SOURCE_DIR}/src/msvc-missing)
+
+target_compile_definitions(${target_name} PRIVATE
+                           HAVE_CONFIG_H
+                           _OFF_T_DEFINED
+                           _off_t=__int64
+                           off_t=_off_t
+                           _FILE_OFFSET_BITS=64
+                           _CRTDBG_MAP_ALLOC)

--- a/src/libcdio/udf/CMakeLists.txt
+++ b/src/libcdio/udf/CMakeLists.txt
@@ -1,0 +1,17 @@
+set(target_name libcdio-udf)
+file(GLOB_RECURSE source_files *.c *.h)
+add_library(${target_name} STATIC ${source_files})
+
+target_include_directories(${target_name} PRIVATE
+                           ${CMAKE_SOURCE_DIR}/src
+                           ${CMAKE_SOURCE_DIR}/src/libcdio
+                           ${CMAKE_SOURCE_DIR}/src/libcdio/driver
+                           ${CMAKE_SOURCE_DIR}/src/msvc-missing)
+
+target_compile_definitions(${target_name} PRIVATE
+                           HAVE_CONFIG_H
+                           _OFF_T_DEFINED
+                           _off_t=__int64
+                           off_t=_off_t
+                           _FILE_OFFSET_BITS=64
+                           _CRTDBG_MAP_ALLOC)

--- a/src/ms-sys/CMakeLists.txt
+++ b/src/ms-sys/CMakeLists.txt
@@ -1,0 +1,5 @@
+set(target_name ms-sys)
+file(GLOB source_files *.c *.h)
+add_library(${target_name} STATIC ${source_files})
+target_include_directories(${target_name} PRIVATE inc)
+target_compile_definitions(${target_name} PRIVATE _CRTDBG_MAP_ALLOC)

--- a/src/syslinux/CMakeLists.txt
+++ b/src/syslinux/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_all_subdirs()

--- a/src/syslinux/libfat/CMakeLists.txt
+++ b/src/syslinux/libfat/CMakeLists.txt
@@ -1,0 +1,11 @@
+set(target_name syslinux-libfat)
+file(GLOB source_files *.c *.h)
+add_library(${target_name} STATIC ${source_files})
+
+target_include_directories(${target_name} PRIVATE
+                           ${CMAKE_SOURCE_DIR}/src
+                           ${CMAKE_SOURCE_DIR}/src/msvc-missing)
+
+target_compile_definitions(${target_name} PRIVATE
+                           inline=__inline
+                           _CRTDBG_MAP_ALLOC)

--- a/src/syslinux/libinstaller/CMakeLists.txt
+++ b/src/syslinux/libinstaller/CMakeLists.txt
@@ -1,0 +1,11 @@
+set(target_name syslinux-libinstaller)
+file(GLOB source_files *.c *.h)
+add_library(${target_name} STATIC ${source_files})
+
+target_include_directories(${target_name} PRIVATE
+                           ${CMAKE_SOURCE_DIR}/src
+                           ${CMAKE_SOURCE_DIR}/src/msvc-missing)
+
+target_compile_definitions(${target_name} PRIVATE
+                           inline=__inline
+                           _CRTDBG_MAP_ALLOC)

--- a/src/syslinux/win/CMakeLists.txt
+++ b/src/syslinux/win/CMakeLists.txt
@@ -1,0 +1,11 @@
+set(target_name syslinux-win)
+file(GLOB source_files *.c *.h)
+add_library(${target_name} STATIC ${source_files})
+
+target_include_directories(${target_name} PRIVATE
+                           ${CMAKE_SOURCE_DIR}/src
+                           ${CMAKE_SOURCE_DIR}/src/msvc-missing)
+
+target_compile_definitions(${target_name} PRIVATE
+                           inline=__inline
+                           _CRTDBG_MAP_ALLOC)


### PR DESCRIPTION
Quick draft for CMake support.

Current state: compiles (but doesn't work).

In the future, it will allow to easily add support other compilers and operating systems (for example Linux).

I'll continue working on it if you're interested.

Usage:

`cmake_vs_32.bat` generates Visual Studio x32 solution in `build_vs_32` folder (`repo` - folder with sources):
```
chcp 65001
set "PATH=%SystemRoot%\system32;c:\programs\cmake\bin"
cmake.exe repo -B build_vs_32 -G "Visual Studio 17" -A Win32
pause
```

`build_vs_32.bat` builds solution:

```
chcp 65001
set "PATH=%SystemRoot%\system32;c:\programs\cmake\bin"
cmake.exe --build build_vs_32 --config Debug
pause
```

and x64

`cmake_vs_64.bat`:

```
chcp 65001
set "PATH=%SystemRoot%\system32;c:\programs\cmake\bin"
cmake.exe repo -B build_vs_64 -G "Visual Studio 17" -A x64
pause
```

`build_vs_64.bat`:

```
chcp 65001
set "PATH=%SystemRoot%\system32;c:\programs\cmake\bin"
cmake.exe --build build_vs_64 --config Debug
pause
```