### PR TITLE
Update Windows To Go docs link

### DIFF
--- a/src/wue.c
+++ b/src/wue.c
@@ -631,7 +631,7 @@ out:
 
 /// <summary>
 /// Setup a Windows To Go drive according to the official Microsoft instructions detailed at:
-/// https://docs.microsoft.com/en-us/previous-versions/windows/it-pro/windows-8.1-and-8/jj721578(v=ws.11).
+/// https://learn.microsoft.com/en-us/previous-versions/windows/it-pro/windows-10/deployment/windows-to-go/deploy-windows-to-go
 /// Note that as opposed to the technet guide above we use bcdedit rather than 'unattend.xml'
 /// to disable the recovery environment.
 /// </summary>


### PR DESCRIPTION
Sorry to bother you with a very small PR. It's just a minor update to the Windows To Go link.

I tried to use a commit message similar to your other ones, prefixing this one with `[core]`. Let me know if you want me to change it - otherwise, you go ahead and do it 😊

Main difference between the Windows 10 and Windows 8 version of the doc is the Windows 10 version has most code samples in collapsed segments, and they have syntax highlighting. 😎

Example:
![san_policy.xml](https://github.com/pbatard/rufus/assets/10890923/6f06e958-8f21-40e9-860e-241bea26f886)
