### PR TITLE
libcdio: fix MSVC-only definition

### DIFF
--- a/src/libcdio/config.h
+++ b/src/libcdio/config.h
@@ -40,7 +40,9 @@
 /* Define to 1 if you have the `fseeko64' function. */
 #define HAVE_FSEEKO64 1
 /* The equivalent of fseeko64 for MSVC is _fseeki64 */
+#if defined(_MSC_VER)
 #define fseeko64 _fseeki64
+#endif
 
 /* Define to 1 if you have the `ftruncate' function. */
 /* #undef HAVE_FTRUNCATE */


### PR DESCRIPTION
according to the comment it should be defined for MSVC only. fixes UCRT build

<!--
Please do not create an unsolicited Pull Requests for a translation update.
See https://github.com/pbatard/rufus/wiki/FAQ#user-content-Why_dont_you_accept_unsolicited_translation_updates.
-->