### PR TITLE
Dark mode for rufus

### DIFF
--- a/.mingw/Makefile.am
+++ b/.mingw/Makefile.am
@@ -20,7 +20,7 @@ TARGET        := $(word 1,$(subst -, ,$(TUPLE)))
 DEF_SUFFIX    := $(if $(TARGET:x86_64=),.def,.def64)
 
 .PHONY: all
-all: crypt32-delaylib.lib dwmapi-delaylib.lib setupapi-delaylib.lib version-delaylib.lib virtdisk-delaylib.lib wininet-delaylib.lib wintrust-delaylib.lib 
+all: crypt32-delaylib.lib dwmapi-delaylib.lib setupapi-delaylib.lib uxtheme-delaylib.lib version-delaylib.lib virtdisk-delaylib.lib wininet-delaylib.lib wintrust-delaylib.lib
 
 %.def64: %.def
 	$(AM_V_SED) "s/@.*//" $< >$@

--- a/.mingw/Makefile.in
+++ b/.mingw/Makefile.in
@@ -368,7 +368,7 @@ uninstall-am:
 
 
 .PHONY: all
-all: crypt32-delaylib.lib dwmapi-delaylib.lib setupapi-delaylib.lib version-delaylib.lib virtdisk-delaylib.lib wininet-delaylib.lib wintrust-delaylib.lib 
+all: crypt32-delaylib.lib dwmapi-delaylib.lib setupapi-delaylib.lib uxtheme-delaylib.lib version-delaylib.lib virtdisk-delaylib.lib wininet-delaylib.lib wintrust-delaylib.lib
 
 %.def64: %.def
 	$(AM_V_SED) "s/@.*//" $< >$@

--- a/.mingw/dwmapi.def
+++ b/.mingw/dwmapi.def
@@ -1,2 +1,4 @@
 EXPORTS
+  DwmGetColorizationColor@8
   DwmGetWindowAttribute@16
+  DwmSetWindowAttribute@16

--- a/.mingw/uxtheme.def
+++ b/.mingw/uxtheme.def
@@ -1,0 +1,15 @@
+EXPORTS
+  BeginBufferedAnimation@32
+  BufferedPaintRenderAnimation@8
+  BufferedPaintStopAllAnimations@4
+  CloseThemeData@4
+  DrawThemeBackground@24
+  DrawThemeParentBackground@12
+  DrawThemeTextEx@36
+  EndBufferedAnimation@8
+  GetThemeBackgroundContentRect@24
+  GetThemeFont@24
+  GetThemePartSize@28
+  GetThemeTransitionDuration@24
+  OpenThemeData@8
+  SetWindowTheme@12

--- a/.vs/rufus.vcxproj
+++ b/.vs/rufus.vcxproj
@@ -133,12 +133,12 @@
       <AdditionalOptions>/utf-8 /std:clatest $(ExternalCompilerOptions) %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>advapi32.lib;comctl32.lib;crypt32.lib;gdi32.lib;ole32.lib;dwmapi.lib;setupapi.lib;shell32.lib;ntdll.lib;shlwapi.lib;version.lib;virtdisk.lib;wininet.lib;wintrust.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>advapi32.lib;comctl32.lib;crypt32.lib;gdi32.lib;ole32.lib;dwmapi.lib;setupapi.lib;shell32.lib;ntdll.lib;shlwapi.lib;uxtheme.lib;version.lib;virtdisk.lib;wininet.lib;wintrust.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <UACExecutionLevel>RequireAdministrator</UACExecutionLevel>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
       <TargetMachine>MachineX86</TargetMachine>
-      <DelayLoadDLLs>advapi32.dll;comctl32.dll;crypt32.dll;gdi32.dll;ole32.dll;dwmapi.dll;setupapi.dll;shell32.dll;shlwapi.dll;version.dll;virtdisk.dll;wininet.dll;wintrust.dll;%(DelayLoadDLLs)</DelayLoadDLLs>
+      <DelayLoadDLLs>advapi32.dll;comctl32.dll;crypt32.dll;gdi32.dll;ole32.dll;dwmapi.dll;setupapi.dll;shell32.dll;shlwapi.dll;uxtheme.dll;version.dll;virtdisk.dll;wininet.dll;wintrust.dll;%(DelayLoadDLLs)</DelayLoadDLLs>
       <AdditionalOptions>/BREPRO /DEPENDENTLOADFLAG:0x800 %(AdditionalOptions)</AdditionalOptions>
     </Link>
     <ResourceCompile>
@@ -163,12 +163,12 @@
       <AdditionalOptions>/utf-8 /std:clatest $(ExternalCompilerOptions) %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>advapi32.lib;comctl32.lib;crypt32.lib;gdi32.lib;ole32.lib;dwmapi.lib;setupapi.lib;shell32.lib;ntdll.lib;shlwapi.lib;version.lib;virtdisk.lib;wininet.lib;wintrust.lib;ole32.lib;advapi32.lib;gdi32.lib;shell32.lib;comdlg32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>advapi32.lib;comctl32.lib;crypt32.lib;gdi32.lib;ole32.lib;dwmapi.lib;setupapi.lib;shell32.lib;ntdll.lib;shlwapi.lib;uxtheme.lib;version.lib;virtdisk.lib;wininet.lib;wintrust.lib;comdlg32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <UACExecutionLevel>RequireAdministrator</UACExecutionLevel>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
       <AdditionalLibraryDirectories>C:\Program Files (x86)\Windows Kits\10\Lib\10.0.15063.0\um\arm</AdditionalLibraryDirectories>
-      <DelayLoadDLLs>advapi32.dll;comctl32.dll;crypt32.dll;gdi32.dll;ole32.dll;dwmapi.dll;setupapi.dll;shell32.dll;shlwapi.dll;version.dll;virtdisk.dll;wininet.dll;wintrust.dll;%(DelayLoadDLLs)</DelayLoadDLLs>
+      <DelayLoadDLLs>advapi32.dll;comctl32.dll;crypt32.dll;gdi32.dll;ole32.dll;dwmapi.dll;setupapi.dll;shell32.dll;shlwapi.dll;uxtheme.dll;version.dll;virtdisk.dll;wininet.dll;wintrust.dll;%(DelayLoadDLLs)</DelayLoadDLLs>
       <AdditionalOptions>/BREPRO /DEPENDENTLOADFLAG:0x800 %(AdditionalOptions)</AdditionalOptions>
     </Link>
     <ResourceCompile>
@@ -195,12 +195,12 @@
       <AdditionalOptions>/utf-8 /std:clatest $(ExternalCompilerOptions) %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>advapi32.lib;comctl32.lib;crypt32.lib;gdi32.lib;ole32.lib;dwmapi.lib;setupapi.lib;shell32.lib;ntdll.lib;shlwapi.lib;version.lib;virtdisk.lib;wininet.lib;wintrust.lib;ole32.lib;advapi32.lib;gdi32.lib;shell32.lib;comdlg32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>advapi32.lib;comctl32.lib;crypt32.lib;gdi32.lib;ole32.lib;dwmapi.lib;setupapi.lib;shell32.lib;ntdll.lib;shlwapi.lib;uxtheme.lib;version.lib;virtdisk.lib;wininet.lib;wintrust.lib;comdlg32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <UACExecutionLevel>RequireAdministrator</UACExecutionLevel>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
       <AdditionalLibraryDirectories>C:\Program Files (x86)\Windows Kits\10\Lib\10.0.16299.0\um\arm64</AdditionalLibraryDirectories>
-      <DelayLoadDLLs>advapi32.dll;comctl32.dll;crypt32.dll;gdi32.dll;ole32.dll;dwmapi.dll;setupapi.dll;shell32.dll;shlwapi.dll;version.dll;virtdisk.dll;wininet.dll;wintrust.dll;%(DelayLoadDLLs)</DelayLoadDLLs>
+      <DelayLoadDLLs>advapi32.dll;comctl32.dll;crypt32.dll;gdi32.dll;ole32.dll;dwmapi.dll;setupapi.dll;shell32.dll;shlwapi.dll;uxtheme.dll;version.dll;virtdisk.dll;wininet.dll;wintrust.dll;%(DelayLoadDLLs)</DelayLoadDLLs>
       <AdditionalOptions>/BREPRO /DEPENDENTLOADFLAG:0x800 %(AdditionalOptions)</AdditionalOptions>
     </Link>
     <ResourceCompile>
@@ -232,12 +232,12 @@
       <AdditionalOptions>/utf-8 /std:clatest $(ExternalCompilerOptions) %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>advapi32.lib;comctl32.lib;crypt32.lib;gdi32.lib;ole32.lib;dwmapi.lib;setupapi.lib;shell32.lib;ntdll.lib;shlwapi.lib;version.lib;virtdisk.lib;wininet.lib;wintrust.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>advapi32.lib;comctl32.lib;crypt32.lib;gdi32.lib;ole32.lib;dwmapi.lib;setupapi.lib;shell32.lib;ntdll.lib;shlwapi.lib;uxtheme.lib;version.lib;virtdisk.lib;wininet.lib;wintrust.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <UACExecutionLevel>RequireAdministrator</UACExecutionLevel>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
       <TargetMachine>MachineX64</TargetMachine>
-      <DelayLoadDLLs>advapi32.dll;comctl32.dll;crypt32.dll;gdi32.dll;ole32.dll;dwmapi.dll;setupapi.dll;shell32.dll;shlwapi.dll;version.dll;virtdisk.dll;wininet.dll;wintrust.dll;%(DelayLoadDLLs)</DelayLoadDLLs>
+      <DelayLoadDLLs>advapi32.dll;comctl32.dll;crypt32.dll;gdi32.dll;ole32.dll;dwmapi.dll;setupapi.dll;shell32.dll;shlwapi.dll;uxtheme.dll;version.dll;virtdisk.dll;wininet.dll;wintrust.dll;%(DelayLoadDLLs)</DelayLoadDLLs>
       <AdditionalOptions>/BREPRO /DEPENDENTLOADFLAG:0x800 %(AdditionalOptions)</AdditionalOptions>
     </Link>
     <ResourceCompile>
@@ -264,13 +264,13 @@
       <StringPooling>true</StringPooling>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>advapi32.lib;comctl32.lib;crypt32.lib;gdi32.lib;ole32.lib;dwmapi.lib;setupapi.lib;shell32.lib;ntdll.lib;shlwapi.lib;version.lib;virtdisk.lib;wininet.lib;wintrust.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>advapi32.lib;comctl32.lib;crypt32.lib;gdi32.lib;ole32.lib;dwmapi.lib;setupapi.lib;shell32.lib;ntdll.lib;shlwapi.lib;uxtheme.lib;version.lib;virtdisk.lib;wininet.lib;wintrust.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <UACExecutionLevel>RequireAdministrator</UACExecutionLevel>
       <GenerateDebugInformation>false</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
       <TargetMachine>MachineX86</TargetMachine>
       <AdditionalOptions>/BREPRO /DEPENDENTLOADFLAG:0x800 %(AdditionalOptions)</AdditionalOptions>
-      <DelayLoadDLLs>advapi32.dll;comctl32.dll;crypt32.dll;gdi32.dll;ole32.dll;dwmapi.dll;setupapi.dll;shell32.dll;shlwapi.dll;version.dll;virtdisk.dll;wininet.dll;wintrust.dll;%(DelayLoadDLLs)</DelayLoadDLLs>
+      <DelayLoadDLLs>advapi32.dll;comctl32.dll;crypt32.dll;gdi32.dll;ole32.dll;dwmapi.dll;setupapi.dll;shell32.dll;shlwapi.dll;uxtheme.dll;version.dll;virtdisk.dll;wininet.dll;wintrust.dll;%(DelayLoadDLLs)</DelayLoadDLLs>
     </Link>
     <ResourceCompile>
       <PreprocessorDefinitions>_UNICODE;UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -296,13 +296,13 @@
       <StringPooling>true</StringPooling>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>advapi32.lib;comctl32.lib;crypt32.lib;gdi32.lib;ole32.lib;dwmapi.lib;setupapi.lib;shell32.lib;ntdll.lib;shlwapi.lib;version.lib;virtdisk.lib;wininet.lib;wintrust.lib;ole32.lib;advapi32.lib;gdi32.lib;shell32.lib;comdlg32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>advapi32.lib;comctl32.lib;crypt32.lib;gdi32.lib;ole32.lib;dwmapi.lib;setupapi.lib;shell32.lib;ntdll.lib;shlwapi.lib;uxtheme.lib;version.lib;virtdisk.lib;wininet.lib;wintrust.lib;comdlg32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <UACExecutionLevel>RequireAdministrator</UACExecutionLevel>
       <GenerateDebugInformation>false</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
       <AdditionalLibraryDirectories>C:\Program Files (x86)\Windows Kits\10\Lib\10.0.15063.0\um\arm</AdditionalLibraryDirectories>
       <AdditionalOptions>/BREPRO /DEPENDENTLOADFLAG:0x800 %(AdditionalOptions)</AdditionalOptions>
-      <DelayLoadDLLs>advapi32.dll;comctl32.dll;crypt32.dll;gdi32.dll;ole32.dll;dwmapi.dll;setupapi.dll;shell32.dll;shlwapi.dll;version.dll;virtdisk.dll;wininet.dll;wintrust.dll;%(DelayLoadDLLs)</DelayLoadDLLs>
+      <DelayLoadDLLs>advapi32.dll;comctl32.dll;crypt32.dll;gdi32.dll;ole32.dll;dwmapi.dll;setupapi.dll;shell32.dll;shlwapi.dll;uxtheme.dll;version.dll;virtdisk.dll;wininet.dll;wintrust.dll;%(DelayLoadDLLs)</DelayLoadDLLs>
     </Link>
     <ResourceCompile>
       <PreprocessorDefinitions>_UNICODE;UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -330,13 +330,13 @@
       <StringPooling>true</StringPooling>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>advapi32.lib;comctl32.lib;crypt32.lib;gdi32.lib;ole32.lib;dwmapi.lib;setupapi.lib;shell32.lib;ntdll.lib;shlwapi.lib;version.lib;virtdisk.lib;wininet.lib;wintrust.lib;ole32.lib;advapi32.lib;gdi32.lib;shell32.lib;comdlg32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>advapi32.lib;comctl32.lib;crypt32.lib;gdi32.lib;ole32.lib;dwmapi.lib;setupapi.lib;shell32.lib;ntdll.lib;shlwapi.lib;uxtheme.lib;version.lib;virtdisk.lib;wininet.lib;wintrust.lib;comdlg32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <UACExecutionLevel>RequireAdministrator</UACExecutionLevel>
       <GenerateDebugInformation>false</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
       <AdditionalLibraryDirectories>C:\Program Files (x86)\Windows Kits\10\Lib\10.0.16299.0\um\arm64</AdditionalLibraryDirectories>
       <AdditionalOptions>/BREPRO /DEPENDENTLOADFLAG:0x800 %(AdditionalOptions)</AdditionalOptions>
-      <DelayLoadDLLs>advapi32.dll;comctl32.dll;crypt32.dll;gdi32.dll;ole32.dll;dwmapi.dll;setupapi.dll;shell32.dll;shlwapi.dll;version.dll;virtdisk.dll;wininet.dll;wintrust.dll;%(DelayLoadDLLs)</DelayLoadDLLs>
+      <DelayLoadDLLs>advapi32.dll;comctl32.dll;crypt32.dll;gdi32.dll;ole32.dll;dwmapi.dll;setupapi.dll;shell32.dll;shlwapi.dll;uxtheme.dll;version.dll;virtdisk.dll;wininet.dll;wintrust.dll;%(DelayLoadDLLs)</DelayLoadDLLs>
     </Link>
     <ResourceCompile>
       <PreprocessorDefinitions>_UNICODE;UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -367,13 +367,13 @@
       <StringPooling>true</StringPooling>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>advapi32.lib;comctl32.lib;crypt32.lib;gdi32.lib;ole32.lib;dwmapi.lib;setupapi.lib;shell32.lib;ntdll.lib;shlwapi.lib;version.lib;virtdisk.lib;wininet.lib;wintrust.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>advapi32.lib;comctl32.lib;crypt32.lib;gdi32.lib;ole32.lib;dwmapi.lib;setupapi.lib;shell32.lib;ntdll.lib;shlwapi.lib;uxtheme.lib;version.lib;virtdisk.lib;wininet.lib;wintrust.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <UACExecutionLevel>RequireAdministrator</UACExecutionLevel>
       <GenerateDebugInformation>false</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
       <TargetMachine>MachineX64</TargetMachine>
       <AdditionalOptions>/BREPRO /DEPENDENTLOADFLAG:0x800 %(AdditionalOptions)</AdditionalOptions>
-      <DelayLoadDLLs>advapi32.dll;comctl32.dll;crypt32.dll;gdi32.dll;ole32.dll;dwmapi.dll;setupapi.dll;shell32.dll;shlwapi.dll;version.dll;virtdisk.dll;wininet.dll;wintrust.dll;%(DelayLoadDLLs)</DelayLoadDLLs>
+      <DelayLoadDLLs>advapi32.dll;comctl32.dll;crypt32.dll;gdi32.dll;ole32.dll;dwmapi.dll;setupapi.dll;shell32.dll;shlwapi.dll;uxtheme.dll;version.dll;virtdisk.dll;wininet.dll;wintrust.dll;%(DelayLoadDLLs)</DelayLoadDLLs>
     </Link>
     <ResourceCompile>
       <PreprocessorDefinitions>_UNICODE;UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -385,6 +385,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="..\src\badblocks.c" />
+    <ClCompile Include="..\src\darkmode.c" />
     <ClCompile Include="..\src\dos_locale.c" />
     <ClCompile Include="..\src\drive.c" />
     <ClCompile Include="..\src\format.c" />
@@ -418,6 +419,7 @@
     <ClInclude Include="..\res\grub\grub_version.h" />
     <ClInclude Include="..\src\badblocks.h" />
     <ClInclude Include="..\src\bled\bled.h" />
+    <ClInclude Include="..\src\darkmode.h" />
     <ClInclude Include="..\src\drive.h" />
     <ClInclude Include="..\src\efi.h" />
     <ClInclude Include="..\src\format.h" />

--- a/.vs/rufus.vcxproj.filters
+++ b/.vs/rufus.vcxproj.filters
@@ -96,6 +96,9 @@
     <ClCompile Include="..\src\xml.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\src\darkmode.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\src\rufus.h">
@@ -204,6 +207,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\src\xml.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\darkmode.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -3,7 +3,7 @@ SUBDIRS = ../.mingw bled ext2fs ms-sys syslinux/libfat syslinux/libinstaller sys
 NONVULNERABLE_LIBS = -lole32 -lgdi32 -lshlwapi -lcomctl32 -luuid -lntdll
 # The following libraries are vulnerable (or have an unknown vulnerability status), so we link using our delay-loaded replacement:
 # See https://github.com/pbatard/rufus/issues/2272
-VULNERABLE_LIBS = -lcrypt32-delaylib -ldwmapi-delaylib -lsetupapi-delaylib -lversion-delaylib -lvirtdisk-delaylib -lwininet-delaylib -lwintrust-delaylib
+VULNERABLE_LIBS = -lcrypt32-delaylib -ldwmapi-delaylib -lsetupapi-delaylib -luxtheme-delaylib -lversion-delaylib -lvirtdisk-delaylib -lwininet-delaylib -lwintrust-delaylib
 
 noinst_PROGRAMS = rufus
 
@@ -15,7 +15,7 @@ AM_V_WINDRES   = $(AM_V_WINDRES_$(V))
 %_rc.o: %.rc ../res/loc/embedded.loc
 	$(AM_V_WINDRES) $(AM_RCFLAGS) -i $< -o $@
 
-rufus_SOURCES = badblocks.c dev.c dos.c dos_locale.c drive.c format.c format_ext.c format_fat32.c hash.c icon.c iso.c \
+rufus_SOURCES = badblocks.c darkmode.c dev.c dos.c dos_locale.c drive.c format.c format_ext.c format_fat32.c hash.c icon.c iso.c \
 	localization.c net.c parser.c pki.c process.c re.c rufus.c smart.c stdfn.c stdio.c stdlg.c syslinux.c ui.c vhd.c wue.c xml.c
 rufus_CFLAGS = -I$(srcdir)/ms-sys/inc -I$(srcdir)/syslinux/libfat -I$(srcdir)/syslinux/libinstaller -I$(srcdir)/syslinux/win -I$(srcdir)/libcdio -I$(srcdir)/wimlib -I$(srcdir)/../res $(AM_CFLAGS) \
 	-DEXT2_FLAT_INCLUDES=0 -D_RUFUS -DSOLUTION=rufus

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -87,8 +87,8 @@ mkinstalldirs = $(install_sh) -d
 CONFIG_CLEAN_FILES =
 CONFIG_CLEAN_VPATH_FILES =
 PROGRAMS = $(noinst_PROGRAMS)
-am_rufus_OBJECTS = rufus-badblocks.$(OBJEXT) rufus-dev.$(OBJEXT) \
-	rufus-dos.$(OBJEXT) rufus-dos_locale.$(OBJEXT) \
+am_rufus_OBJECTS = rufus-badblocks.$(OBJEXT) rufus-darkmode.$(OBJEXT) \
+	rufus-dev.$(OBJEXT) rufus-dos.$(OBJEXT) rufus-dos_locale.$(OBJEXT) \
 	rufus-drive.$(OBJEXT) rufus-format.$(OBJEXT) \
 	rufus-format_ext.$(OBJEXT) rufus-format_fat32.$(OBJEXT) \
 	rufus-hash.$(OBJEXT) rufus-icon.$(OBJEXT) rufus-iso.$(OBJEXT) \
@@ -117,30 +117,30 @@ am__v_P_1 = :
 AM_V_GEN = $(am__v_GEN_@AM_V@)
 am__v_GEN_ = $(am__v_GEN_@AM_DEFAULT_V@)
 am__v_GEN_0 = @echo "  GEN     " $@;
-am__v_GEN_1 = 
+am__v_GEN_1 =
 AM_V_at = $(am__v_at_@AM_V@)
 am__v_at_ = $(am__v_at_@AM_DEFAULT_V@)
 am__v_at_0 = @
-am__v_at_1 = 
+am__v_at_1 =
 DEFAULT_INCLUDES = -I.@am__isrc@
 depcomp =
 am__depfiles_maybe =
 AM_V_lt = $(am__v_lt_@AM_V@)
 am__v_lt_ = $(am__v_lt_@AM_DEFAULT_V@)
 am__v_lt_0 = --silent
-am__v_lt_1 = 
+am__v_lt_1 =
 COMPILE = $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) \
 	$(CPPFLAGS) $(AM_CFLAGS) $(CFLAGS)
 AM_V_CC = $(am__v_CC_@AM_V@)
 am__v_CC_ = $(am__v_CC_@AM_DEFAULT_V@)
 am__v_CC_0 = @echo "  CC      " $@;
-am__v_CC_1 = 
+am__v_CC_1 =
 CCLD = $(CC)
 LINK = $(CCLD) $(AM_CFLAGS) $(CFLAGS) $(AM_LDFLAGS) $(LDFLAGS) -o $@
 AM_V_CCLD = $(am__v_CCLD_@AM_V@)
 am__v_CCLD_ = $(am__v_CCLD_@AM_DEFAULT_V@)
 am__v_CCLD_0 = @echo "  CCLD    " $@;
-am__v_CCLD_1 = 
+am__v_CCLD_1 =
 SOURCES = $(rufus_SOURCES)
 RECURSIVE_TARGETS = all-recursive check-recursive cscopelist-recursive \
 	ctags-recursive dvi-recursive html-recursive info-recursive \
@@ -278,12 +278,12 @@ SUBDIRS = ../.mingw bled ext2fs ms-sys syslinux/libfat syslinux/libinstaller sys
 NONVULNERABLE_LIBS = -lole32 -lgdi32 -lshlwapi -lcomctl32 -luuid -lntdll
 # The following libraries are vulnerable (or have an unknown vulnerability status), so we link using our delay-loaded replacement:
 # See https://github.com/pbatard/rufus/issues/2272
-VULNERABLE_LIBS = -lcrypt32-delaylib -ldwmapi-delaylib -lsetupapi-delaylib -lversion-delaylib -lvirtdisk-delaylib -lwininet-delaylib -lwintrust-delaylib
+VULNERABLE_LIBS = -lcrypt32-delaylib -ldwmapi-delaylib -lsetupapi-delaylib -luxtheme-delaylib -lversion-delaylib -lvirtdisk-delaylib -lwininet-delaylib -lwintrust-delaylib
 AM_V_WINDRES_0 = @echo "  RC     $@";$(WINDRES)
 AM_V_WINDRES_1 = $(WINDRES)
 AM_V_WINDRES_ = $(AM_V_WINDRES_$(AM_DEFAULT_VERBOSITY))
 AM_V_WINDRES = $(AM_V_WINDRES_$(V))
-rufus_SOURCES = badblocks.c dev.c dos.c dos_locale.c drive.c format.c format_ext.c format_fat32.c hash.c icon.c iso.c \
+rufus_SOURCES = badblocks.c darkmode.c dev.c dos.c dos_locale.c drive.c format.c format_ext.c format_fat32.c hash.c icon.c iso.c \
 	localization.c net.c parser.c pki.c process.c re.c rufus.c smart.c stdfn.c stdio.c stdlg.c syslinux.c ui.c vhd.c wue.c xml.c
 
 rufus_CFLAGS = -I$(srcdir)/ms-sys/inc -I$(srcdir)/syslinux/libfat -I$(srcdir)/syslinux/libinstaller -I$(srcdir)/syslinux/win -I$(srcdir)/libcdio -I$(srcdir)/wimlib -I$(srcdir)/../res $(AM_CFLAGS) \
@@ -331,7 +331,7 @@ $(am__aclocal_m4_deps):
 clean-noinstPROGRAMS:
 	-test -z "$(noinst_PROGRAMS)" || rm -f $(noinst_PROGRAMS)
 
-rufus$(EXEEXT): $(rufus_OBJECTS) $(rufus_DEPENDENCIES) $(EXTRA_rufus_DEPENDENCIES) 
+rufus$(EXEEXT): $(rufus_OBJECTS) $(rufus_DEPENDENCIES) $(EXTRA_rufus_DEPENDENCIES)
 	@rm -f rufus$(EXEEXT)
 	$(AM_V_CCLD)$(rufus_LINK) $(rufus_OBJECTS) $(rufus_LDADD) $(LIBS)
 
@@ -352,6 +352,12 @@ rufus-badblocks.o: badblocks.c
 
 rufus-badblocks.obj: badblocks.c
 	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(rufus_CFLAGS) $(CFLAGS) -c -o rufus-badblocks.obj `if test -f 'badblocks.c'; then $(CYGPATH_W) 'badblocks.c'; else $(CYGPATH_W) '$(srcdir)/badblocks.c'; fi`
+
+rufus-darkmode.o: darkmode.c
+	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(rufus_CFLAGS) $(CFLAGS) -c -o rufus-darkmode.o `test -f 'darkmode.c' || echo '$(srcdir)/'`darkmode.c
+
+rufus-darkmode.obj: darkmode.c
+	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(rufus_CFLAGS) $(CFLAGS) -c -o rufus-darkmode.obj `if test -f 'darkmode.c'; then $(CYGPATH_W) 'darkmode.c'; else $(CYGPATH_W) '$(srcdir)/darkmode.c'; fi`
 
 rufus-dev.o: dev.c
 	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(rufus_CFLAGS) $(CFLAGS) -c -o rufus-dev.o `test -f 'dev.c' || echo '$(srcdir)/'`dev.c

--- a/src/darkmode.c
+++ b/src/darkmode.c
@@ -291,6 +291,11 @@ BOOL ChangeIconColor(HICON* hIcon, COLORREF newColor) {
 					if (hbm) {
 						SetDIBits(hdcBitmap, hbm, 0, bm.bmHeight, pixels, &bmi, DIB_RGB_COLORS);
 
+						if (ii.hbmColor) {
+							DeleteObject(ii.hbmColor);
+							ii.hbmColor = NULL;
+						}
+
 						ii.hbmColor = hbm;
 						hIconNew = CreateIconIndirect(&ii);
 					}
@@ -1333,7 +1338,7 @@ static LRESULT CALLBACK ProgressBarSubclass(
 		EndPaint(hWnd, &ps);
 
 		return 0;
-		
+
 	}
 	}
 	return DefSubclassProc(hWnd, uMsg, wParam, lParam);

--- a/src/darkmode.c
+++ b/src/darkmode.c
@@ -956,8 +956,7 @@ static LRESULT DarkTrackBarNotifyCustomDraw(HWND hWnd, UINT uMsg, WPARAM wParam,
 
 		case TBCD_CHANNEL:
 		{
-			const LONG_PTR nStyle = GetWindowLongPtr(lpnmcd->hdr.hwndFrom, GWL_STYLE);
-			if ((nStyle & WS_DISABLED) == WS_DISABLED) {
+			if (IsWindowEnabled(lpnmcd->hdr.hwndFrom) == FALSE) {
 				FillRect(lpnmcd->hdc, &lpnmcd->rc, GetBackgroundBrush());
 				PaintRoundFrameRect(lpnmcd->hdc, lpnmcd->rc, GetEdgePen(), 0, 0);
 			}
@@ -1272,7 +1271,7 @@ static LRESULT CALLBACK ProgressBarSubclass(
 	switch (uMsg) {
 	case WM_NCDESTROY:
 	{
-		RemoveWindowSubclass(hWnd, ButtonSubclass, uIdSubclass);
+		RemoveWindowSubclass(hWnd, ProgressBarSubclass, uIdSubclass);
 		if (pProgressBarData->hTheme) {
 			CloseThemeData(pProgressBarData->hTheme);
 		}

--- a/src/darkmode.c
+++ b/src/darkmode.c
@@ -1,0 +1,1695 @@
+/*
+ * Rufus: The Reliable USB Formatting Utility
+ * Dark mode for Rufus
+ * Copyright © 2025 ozone10
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "darkmode.h"
+#include "rufus.h"
+#include <dwmapi.h>
+#include <math.h>
+#include <richedit.h>
+#include <Shlwapi.h>
+#include <Uxtheme.h>
+#include <VersionHelpers.h>
+#include <vssym32.h>
+
+
+#define WIN10_22H2 19045 // Windows 10 22H2 (Last)
+#define WIN11_21H2 22000 // Windows 11 first "stable" build
+
+#define TOOLBAR_ICON_COLOR      RGB(0x29, 0x80, 0xB9) // from "ui.h"
+#define TOOLBAR_ICON_COLOR_GOLD RGB(0xFF, 0xD7, 0x00) // gold
+static COLORREF cAccent = TOOLBAR_ICON_COLOR;
+
+typedef enum _PreferredAppMode {
+	Default,
+	AllowDark,
+	ForceDark,
+	ForceLight,
+	Max
+} PreferredAppMode;
+
+typedef enum _WINDOWCOMPOSITIONATTRIB {
+	WCA_UNDEFINED = 0,
+	WCA_NCRENDERING_ENABLED = 1,
+	WCA_NCRENDERING_POLICY = 2,
+	WCA_TRANSITIONS_FORCEDISABLED = 3,
+	WCA_ALLOW_NCPAINT = 4,
+	WCA_CAPTION_BUTTON_BOUNDS = 5,
+	WCA_NONCLIENT_RTL_LAYOUT = 6,
+	WCA_FORCE_ICONIC_REPRESENTATION = 7,
+	WCA_EXTENDED_FRAME_BOUNDS = 8,
+	WCA_HAS_ICONIC_BITMAP = 9,
+	WCA_THEME_ATTRIBUTES = 10,
+	WCA_NCRENDERING_EXILED = 11,
+	WCA_NCADORNMENTINFO = 12,
+	WCA_EXCLUDED_FROM_LIVEPREVIEW = 13,
+	WCA_VIDEO_OVERLAY_ACTIVE = 14,
+	WCA_FORCE_ACTIVEWINDOW_APPEARANCE = 15,
+	WCA_DISALLOW_PEEK = 16,
+	WCA_CLOAK = 17,
+	WCA_CLOAKED = 18,
+	WCA_ACCENT_POLICY = 19,
+	WCA_FREEZE_REPRESENTATION = 20,
+	WCA_EVER_UNCLOAKED = 21,
+	WCA_VISUAL_OWNER = 22,
+	WCA_HOLOGRAPHIC = 23,
+	WCA_EXCLUDED_FROM_DDA = 24,
+	WCA_PASSIVEUPDATEMODE = 25,
+	WCA_USEDARKMODECOLORS = 26,
+	WCA_LAST = 27
+} WINDOWCOMPOSITIONATTRIB;
+
+typedef struct _WINDOWCOMPOSITIONATTRIBDATA {
+	WINDOWCOMPOSITIONATTRIB Attrib;
+	PVOID pvData;
+	SIZE_T cbData;
+} WINDOWCOMPOSITIONATTRIBDATA;
+
+
+PF_TYPE_DECL(WINAPI, BOOL, AllowDarkModeForWindow, (HWND, BOOL));
+PF_TYPE_DECL(WINAPI, PreferredAppMode, SetPreferredAppMode, (PreferredAppMode));
+PF_TYPE_DECL(WINAPI, VOID, FlushMenuThemes, (VOID));
+PF_TYPE_DECL(WINAPI, BOOL, SetWindowCompositionAttribute, (HWND, WINDOWCOMPOSITIONATTRIBDATA*));
+
+static BOOL isDarkEnabled = FALSE;
+
+BOOL IsAtLeastWin10Build(DWORD buildNumber)
+{
+	if (!IsWindows10OrGreater()) {
+		return FALSE;
+	}
+
+	const ULONGLONG mask = VerSetConditionMask(0, VER_BUILDNUMBER, VER_GREATER_EQUAL);
+
+	OSVERSIONINFOEXW osvi;
+	ZeroMemory(&osvi, sizeof(OSVERSIONINFOEXW));
+	osvi.dwOSVersionInfoSize = sizeof(osvi);
+	osvi.dwBuildNumber = buildNumber;
+	return VerifyVersionInfoW(&osvi, VER_BUILDNUMBER, mask);
+}
+
+static BOOL IsAtLeastWin10(void)
+{
+	return IsAtLeastWin10Build(WIN10_22H2);
+}
+
+static BOOL IsAtLeastWin11(void)
+{
+	return IsAtLeastWin10Build(WIN11_21H2);
+}
+
+BOOL IsDarkModeEnabled(void)
+{
+	return isDarkEnabled;
+}
+
+BOOL GetDarkModeFromReg(void)
+{
+	DWORD data = 0;
+	DWORD dwBufSize = sizeof(data);
+	LPCWSTR lpSubKey = L"Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize";
+	LPCWSTR lpValue = L"AppsUseLightTheme";
+
+	LSTATUS result = RegGetValueW(HKEY_CURRENT_USER, lpSubKey, lpValue, RRF_RT_REG_DWORD, NULL, &data, &dwBufSize);
+	if (result != ERROR_SUCCESS) {
+		isDarkEnabled = FALSE;
+		return isDarkEnabled;
+	}
+
+	// dark mode is 0, light mode is 1
+	isDarkEnabled = (data == 0) ? TRUE : FALSE;
+	return isDarkEnabled;
+}
+
+
+void InitDarkMode(HWND hWnd) {
+	if (!IsAtLeastWin10()) {
+		return;
+	}
+
+	BOOL enableDark = IsDarkModeEnabled();
+
+	PF_INIT_ID_OR_OUT(AllowDarkModeForWindow, UxTheme, 133);
+	PF_INIT_ID_OR_OUT(SetPreferredAppMode, UxTheme, 135);
+	PF_INIT_ID_OR_OUT(FlushMenuThemes, UxTheme, 136);
+
+	pfAllowDarkModeForWindow(hWnd, enableDark);
+	PreferredAppMode appMode = enableDark ? ForceDark : ForceLight;
+	pfSetPreferredAppMode(appMode);
+	pfFlushMenuThemes();
+	return;
+
+out:
+	isDarkEnabled = FALSE;
+	return;
+}
+
+void SetDarkTitleBar(HWND hWnd)
+{
+	BOOL dark = IsDarkModeEnabled();
+
+	if (IsAtLeastWin11()) {
+		DwmSetWindowAttribute(hWnd, DWMWA_USE_IMMERSIVE_DARK_MODE, &dark, sizeof(dark));
+	}
+	else if (IsAtLeastWin10()) {
+		PF_INIT_OR_OUT(SetWindowCompositionAttribute, user32);
+
+		WINDOWCOMPOSITIONATTRIBDATA data = { WCA_USEDARKMODECOLORS, &dark, sizeof(dark) };
+		pfSetWindowCompositionAttribute(hWnd, &data);
+	}
+	else {
+out:
+		isDarkEnabled = FALSE;
+	}
+}
+
+void SetDarkTheme(HWND hWnd)
+{
+	SetWindowTheme(hWnd, IsDarkModeEnabled() ? L"DarkMode_Explorer" : NULL, NULL);
+}
+
+/*
+ * Accent color functions
+ */
+
+// adapted from https://stackoverflow.com/a/56678483
+static double LinearValue(double colorChannel)
+{
+	colorChannel /= 255.0;
+	if (colorChannel <= 0.04045) {
+		return colorChannel / 12.92;
+	}
+	return pow((colorChannel + 0.055) / 1.055, 2.4);
+}
+
+static double CalculatePerceivedLightness(COLORREF c)
+{
+	double r = LinearValue((double)GetRValue(c));
+	double g = LinearValue((double)GetGValue(c));
+	double b = LinearValue((double)GetBValue(c));
+
+	double luminance = 0.2126 * r + 0.7152 * g + 0.0722 * b;
+
+	double lightness = (luminance <= 216.0 / 24389.0) ?
+		(luminance * 24389.0 / 27.0) :
+		(pow(luminance, 1.0 / 3.0) * 116.0 - 16.0);
+
+	return lightness;
+}
+
+BOOL InitAccentColor(void)
+{
+	BOOL opaque = TRUE;
+	if (IsDarkModeEnabled() && SUCCEEDED(DwmGetColorizationColor(&cAccent, &opaque))) {
+		cAccent = RGB(GetBValue(cAccent), GetGValue(cAccent), GetRValue(cAccent));
+		// check if accent color is too dark
+		static double lightnessTreshold = 50.0 - 4.0;
+		if (CalculatePerceivedLightness(cAccent) < lightnessTreshold) {
+			cAccent = TOOLBAR_ICON_COLOR_GOLD;
+			return FALSE;
+		}
+		return TRUE;
+	}
+	cAccent = TOOLBAR_ICON_COLOR;
+	return FALSE;
+}
+
+static COLORREF GetAccentColor(void)
+{
+	return cAccent;
+}
+
+// Rufus has only icons with one color, so changing color is easy
+BOOL ChangeIconColor(HICON* hIcon, COLORREF newColor) {
+	HDC hdcScreen, hdcBitmap = NULL;
+	HBITMAP hbm = NULL;
+	BITMAP bm;
+	ZeroMemory(&bm, sizeof(BITMAP));
+	ICONINFO ii;
+	HICON hIconNew = NULL;
+	RGBQUAD* pixels = NULL;
+
+	if (!*hIcon || !IsDarkModeEnabled()) {
+		return FALSE;
+	}
+
+	if (newColor == 0) {
+		newColor = GetAccentColor();
+	}
+
+	hdcBitmap = CreateCompatibleDC(NULL);
+	hdcScreen = GetDC(NULL);
+	if (hdcScreen) {
+		if (hdcBitmap) {
+			if (GetIconInfo(*hIcon, &ii) && GetObject(ii.hbmColor, sizeof(BITMAP), &bm)) {
+				BITMAPINFO bmi = { 0 };
+				bmi.bmiHeader.biSize = sizeof(BITMAPINFOHEADER);
+				bmi.bmiHeader.biWidth = bm.bmWidth;
+				bmi.bmiHeader.biHeight = -bm.bmHeight;
+				bmi.bmiHeader.biPlanes = 1;
+				bmi.bmiHeader.biBitCount = 32;
+				bmi.bmiHeader.biCompression = BI_RGB;
+
+				pixels = (RGBQUAD*)malloc((size_t)bm.bmWidth * bm.bmHeight * sizeof(RGBQUAD));
+				if (pixels && GetDIBits(hdcBitmap, ii.hbmColor, 0, bm.bmHeight, pixels, &bmi, DIB_RGB_COLORS)) {
+					for (int i = 0; i < bm.bmWidth * bm.bmHeight; i++) {
+						if (pixels[i].rgbReserved != 0) {
+							pixels[i].rgbRed = GetRValue(newColor);
+							pixels[i].rgbGreen = GetGValue(newColor);
+							pixels[i].rgbBlue = GetBValue(newColor);
+						}
+					}
+
+					hbm = CreateCompatibleBitmap(hdcScreen, bm.bmWidth, bm.bmHeight);
+					if (hbm) {
+						SetDIBits(hdcBitmap, hbm, 0, bm.bmHeight, pixels, &bmi, DIB_RGB_COLORS);
+
+						ii.hbmColor = hbm;
+						hIconNew = CreateIconIndirect(&ii);
+					}
+					else {
+						free(pixels);
+						pixels = NULL;
+						DeleteObject(ii.hbmColor);
+						DeleteObject(ii.hbmMask);
+						DeleteDC(hdcBitmap);
+						ReleaseDC(NULL, hdcScreen);
+						return FALSE;
+					}
+				}
+
+				free(pixels);
+				pixels = NULL;
+				if (hbm) DeleteObject(hbm);
+				DeleteObject(ii.hbmColor);
+				DeleteObject(ii.hbmMask);
+			}
+		}
+		ReleaseDC(NULL, hdcScreen);
+	}
+
+	if (hdcBitmap) {
+		DeleteDC(hdcBitmap);
+	}
+
+	if (!hIconNew) {
+		return FALSE;
+	}
+	DestroyIcon(*hIcon);
+	*hIcon = hIconNew;
+
+	return TRUE;
+}
+
+/*
+ * Dark mode custom colors
+ */
+
+static HBRUSH hbrBackground = NULL;
+static HBRUSH hbrBackgroundControl = NULL;
+static HBRUSH hbrBackgroundHot = NULL;
+static HBRUSH hbrEdge = NULL;
+static HPEN hpnEdge = NULL;
+static HPEN hpnEdgeHot = NULL;
+
+COLORREF GetTextColorForDarkMode(void)
+{
+	return 0xE0E0E0;
+}
+
+COLORREF GetDisabledTextColor(void)
+{
+	return 0x808080;
+}
+
+static COLORREF GetBackgroundColor(void)
+{
+	return 0x202020;
+}
+
+COLORREF GetControlBackgroundColor(void)
+{
+	return 0x383838;
+}
+
+static COLORREF GetHotBackgroundColor(void)
+{
+	return 0x454545;
+}
+
+COLORREF GetEdgeColor(void)
+{
+	return 0x646464;
+}
+
+static COLORREF GetHotEdgeColor(void)
+{
+	return 0x9B9B9B;
+}
+
+static HBRUSH GetBackgroundBrush(void)
+{
+	if (hbrBackground == NULL) {
+		hbrBackground = CreateSolidBrush(GetBackgroundColor());
+	}
+	return hbrBackground;
+}
+
+static HBRUSH GetControlBackgroundBrush(void)
+{
+	if (hbrBackgroundControl == NULL) {
+		hbrBackgroundControl = CreateSolidBrush(GetControlBackgroundColor());
+	}
+	return hbrBackgroundControl;
+}
+
+static HBRUSH GetHotBackgroundBrush(void)
+{
+	if (hbrBackgroundHot == NULL) {
+		hbrBackgroundHot = CreateSolidBrush(GetHotBackgroundColor());
+	}
+	return hbrBackgroundHot;
+}
+
+static HBRUSH GetEdgeBrush(void)
+{
+	if (hbrEdge == NULL) {
+		hbrEdge = CreateSolidBrush(GetEdgeColor());
+	}
+	return hbrEdge;
+}
+
+static HPEN GetEdgePen(void)
+{
+	if (hpnEdge == NULL) {
+		hpnEdge = CreatePen(PS_SOLID, 1, GetEdgeColor());
+	}
+	return hpnEdge;
+}
+static HPEN GetHotEdgePen(void)
+{
+	if (hpnEdgeHot == NULL) {
+		hpnEdgeHot = CreatePen(PS_SOLID, 1, GetHotEdgeColor());
+	}
+	return hpnEdgeHot;
+}
+
+void DestroyDarkModeGDIObjects(void)
+{
+	safe_delete_object(hbrBackground);
+	safe_delete_object(hbrBackgroundControl);
+	safe_delete_object(hbrBackgroundHot);
+	safe_delete_object(hbrEdge);
+	safe_delete_object(hpnEdge);
+	safe_delete_object(hpnEdgeHot);
+}
+
+/*
+ * Button section, checkbox, radio, and groupbox style buttons
+ */
+static void PaintRoundFrameRect(HDC hdc, const RECT rect, const HPEN hpen, int width, int height)
+{
+	HBRUSH holdBrush = (HBRUSH)SelectObject(hdc, GetStockObject(NULL_BRUSH));
+	HPEN holdPen = (HPEN)SelectObject(hdc, hpen);
+	RoundRect(hdc, rect.left, rect.top, rect.right, rect.bottom, width, height);
+	SelectObject(hdc, holdBrush);
+	SelectObject(hdc, holdPen);
+}
+
+typedef struct _ButtonData {
+	HTHEME hTheme;
+	int iStateID;
+} ButtonData;
+
+const UINT_PTR g_buttonSubclassID = 42;
+const UINT_PTR g_groupboxSubclassID = 42;
+
+static void RenderButton(HWND hWnd, HDC hdc, HTHEME hTheme, int iPartID, int iStateID)
+{
+	RECT rcClient = { 0 };
+	wchar_t szText[256] = { '\0' };
+	DWORD nState = (DWORD)SendMessage(hWnd, BM_GETSTATE, 0, 0);
+	DWORD uiState = (DWORD)SendMessage(hWnd, WM_QUERYUISTATE, 0, 0);
+	LONG_PTR nStyle = GetWindowLongPtr(hWnd, GWL_STYLE);
+
+	HFONT hFont = NULL;
+	HFONT hOldFont = NULL;
+	HFONT hCreatedFont = NULL;
+	LOGFONT lf;
+	if (SUCCEEDED(GetThemeFont(hTheme, hdc, iPartID, iStateID, TMT_FONT, &lf))) {
+		hCreatedFont = CreateFontIndirect(&lf);
+		hFont = hCreatedFont;
+	}
+
+	if (!hFont) {
+		hFont = (HFONT)SendMessage(hWnd, WM_GETFONT, 0, 0);
+	}
+
+	hOldFont = (HFONT)SelectObject(hdc, hFont);
+
+	DWORD dtFlags = DT_LEFT; // DT_LEFT is 0
+	dtFlags |= (nStyle & BS_MULTILINE) ? DT_WORDBREAK : DT_SINGLELINE;
+	dtFlags |= ((nStyle & BS_CENTER) == BS_CENTER) ? DT_CENTER : (nStyle & BS_RIGHT) ? DT_RIGHT : 0;
+	dtFlags |= ((nStyle & BS_VCENTER) == BS_VCENTER) ? DT_VCENTER : (nStyle & BS_BOTTOM) ? DT_BOTTOM : 0;
+	dtFlags |= (uiState & UISF_HIDEACCEL) ? DT_HIDEPREFIX : 0;
+
+	if (!(nStyle & BS_MULTILINE) && !(nStyle & BS_BOTTOM) && !(nStyle & BS_TOP)) {
+		dtFlags |= DT_VCENTER;
+	}
+
+	GetClientRect(hWnd, &rcClient);
+	GetWindowText(hWnd, szText, _countof(szText));
+
+	SIZE szBox = { 13, 13 };
+	GetThemePartSize(hTheme, hdc, iPartID, iStateID, NULL, TS_DRAW, &szBox);
+
+	RECT rcText = rcClient;
+	GetThemeBackgroundContentRect(hTheme, hdc, iPartID, iStateID, &rcClient, &rcText);
+
+	RECT rcBackground = rcClient;
+	if ((dtFlags & DT_SINGLELINE) == DT_SINGLELINE) {
+		rcBackground.top += (rcText.bottom - rcText.top - szBox.cy) / 2;
+	}
+	rcBackground.bottom = rcBackground.top + szBox.cy;
+	rcBackground.right = rcBackground.left + szBox.cx;
+	rcText.left = rcBackground.right + 3;
+
+	DrawThemeParentBackground(hWnd, hdc, &rcClient);
+	DrawThemeBackground(hTheme, hdc, iPartID, iStateID, &rcBackground, NULL);
+
+	DTTOPTS dtto;
+	ZeroMemory(&dtto, sizeof(DTTOPTS));
+	dtto.dwSize = sizeof(DTTOPTS);
+	dtto.dwFlags = DTT_TEXTCOLOR;
+	dtto.crText = ((nStyle & WS_DISABLED) == WS_DISABLED) ? GetDisabledTextColor() : GetTextColorForDarkMode();
+
+	DrawThemeTextEx(hTheme, hdc, iPartID, iStateID, szText, -1, dtFlags, &rcText, &dtto);
+
+	if (((nState & BST_FOCUS) == BST_FOCUS) && ((uiState & UISF_HIDEFOCUS) != UISF_HIDEFOCUS)) {
+		RECT rcTextOut = rcText;
+		dtto.dwFlags |= DTT_CALCRECT;
+		DrawThemeTextEx(hTheme, hdc, iPartID, iStateID, szText, -1, dtFlags | DT_CALCRECT, &rcTextOut, &dtto);
+		RECT rcFocus = rcTextOut;
+		rcFocus.bottom++;
+		rcFocus.left--;
+		rcFocus.right++;
+		DrawFocusRect(hdc, &rcFocus);
+	}
+
+	if (hCreatedFont) {
+		DeleteObject(hCreatedFont);
+	}
+	SelectObject(hdc, hOldFont);
+}
+
+static void PaintButton(HWND hWnd, HDC hdc, ButtonData buttonData)
+{
+	DWORD nState = (DWORD)SendMessage(hWnd, BM_GETSTATE, 0, 0);
+	const LONG_PTR nStyle = GetWindowLongPtr(hWnd, GWL_STYLE);
+	const LONG_PTR nButtonStyle = nStyle & BS_TYPEMASK;
+
+	int iPartID = BP_CHECKBOX;
+
+	if (nButtonStyle == BS_CHECKBOX ||
+		nButtonStyle == BS_AUTOCHECKBOX ||
+		nButtonStyle == BS_3STATE ||
+		nButtonStyle == BS_AUTO3STATE) {
+		iPartID = BP_CHECKBOX;
+	}
+	else if (nButtonStyle == BS_RADIOBUTTON ||
+		nButtonStyle == BS_AUTORADIOBUTTON) {
+		iPartID = BP_RADIOBUTTON;
+	}
+
+	// states of BP_CHECKBOX and BP_RADIOBUTTON are the same
+	int iStateID = RBS_UNCHECKEDNORMAL;
+
+	if (nStyle & WS_DISABLED)		iStateID = RBS_UNCHECKEDDISABLED;
+	else if (nState & BST_PUSHED)	iStateID = RBS_UNCHECKEDPRESSED;
+	else if (nState & BST_HOT)		iStateID = RBS_UNCHECKEDHOT;
+
+	if (nState & BST_CHECKED)		iStateID += 4;
+
+	if (BufferedPaintRenderAnimation(hWnd, hdc)) {
+		return;
+	}
+
+	BP_ANIMATIONPARAMS animParams;
+	ZeroMemory(&animParams, sizeof(BP_ANIMATIONPARAMS));
+	animParams.cbSize = sizeof(BP_ANIMATIONPARAMS);
+	animParams.style = BPAS_LINEAR;
+	if (iStateID != buttonData.iStateID) {
+		GetThemeTransitionDuration(buttonData.hTheme, iPartID, buttonData.iStateID, iStateID, TMT_TRANSITIONDURATIONS, &animParams.dwDuration);
+	}
+
+	RECT rcClient = { 0 };
+	GetClientRect(hWnd, &rcClient);
+
+	HDC hdcFrom = NULL;
+	HDC hdcTo = NULL;
+	HANIMATIONBUFFER hbpAnimation = BeginBufferedAnimation(hWnd, hdc, &rcClient, BPBF_COMPATIBLEBITMAP, NULL, &animParams, &hdcFrom, &hdcTo);
+	if (hbpAnimation) {
+		if (hdcFrom) {
+			RenderButton(hWnd, hdcFrom, buttonData.hTheme, iPartID, buttonData.iStateID);
+		}
+		if (hdcTo) {
+			RenderButton(hWnd, hdcTo, buttonData.hTheme, iPartID, iStateID);
+		}
+
+		buttonData.iStateID = iStateID;
+
+		EndBufferedAnimation(hbpAnimation, TRUE);
+	}
+	else {
+		RenderButton(hWnd, hdc, buttonData.hTheme, iPartID, iStateID);
+
+		buttonData.iStateID = iStateID;
+	}
+}
+
+static LRESULT CALLBACK ButtonSubclass(
+	HWND hWnd,
+	UINT uMsg,
+	WPARAM wParam,
+	LPARAM lParam,
+	UINT_PTR uIdSubclass,
+	DWORD_PTR dwRefData
+)
+{
+	ButtonData* pButtonData = (ButtonData*)dwRefData;
+
+	switch (uMsg)
+	{
+	case WM_UPDATEUISTATE:
+	{
+		if (HIWORD(wParam) & (UISF_HIDEACCEL | UISF_HIDEFOCUS)) {
+			InvalidateRect(hWnd, NULL, FALSE);
+		}
+		break;
+	}
+
+	case WM_NCDESTROY:
+	{
+		RemoveWindowSubclass(hWnd, ButtonSubclass, uIdSubclass);
+		if (pButtonData->hTheme) {
+			CloseThemeData(pButtonData->hTheme);
+		}
+		free(pButtonData);
+		break;
+	}
+
+	case WM_ERASEBKGND:
+	{
+		if (IsDarkModeEnabled()) {
+			if (pButtonData->hTheme == NULL) {
+				pButtonData->hTheme = OpenThemeData(hWnd, VSCLASS_BUTTON);
+			}
+
+			if (pButtonData->hTheme) {
+				return TRUE;
+			}
+		}
+		break;
+	}
+
+	case WM_DPICHANGED:
+	case WM_THEMECHANGED:
+	{
+		if (pButtonData->hTheme) {
+			CloseThemeData(pButtonData->hTheme);
+		}
+		break;
+	}
+
+	case WM_PRINTCLIENT:
+	case WM_PAINT:
+	{
+		if (IsDarkModeEnabled()) {
+			if (pButtonData->hTheme == NULL) {
+				pButtonData->hTheme = OpenThemeData(hWnd, VSCLASS_BUTTON);
+				if (pButtonData->hTheme == NULL) {
+					break;
+				}
+			}
+			PAINTSTRUCT ps;
+			ZeroMemory(&ps, sizeof(PAINTSTRUCT));
+			HDC hdc = (HDC)wParam;
+			if (!hdc) {
+				hdc = BeginPaint(hWnd, &ps);
+			}
+
+			PaintButton(hWnd, hdc, *pButtonData);
+
+			if (ps.hdc) {
+				EndPaint(hWnd, &ps);
+			}
+
+			return 0;
+		}
+		break;
+	}
+
+	case WM_SIZE:
+	case WM_DESTROY:
+	{
+		BufferedPaintStopAllAnimations(hWnd);
+		break;
+	}
+
+	case WM_ENABLE:
+	{
+		if (IsDarkModeEnabled()) {
+			// skip the button's normal wndproc so it won't redraw out of wm_paint
+			LRESULT lr = DefWindowProc(hWnd, uMsg, wParam, lParam);
+			InvalidateRect(hWnd, NULL, FALSE);
+			return lr;
+		}
+		break;
+	}
+	}
+	return DefSubclassProc(hWnd, uMsg, wParam, lParam);
+}
+
+static void SubclassButtonControl(HWND hWnd)
+{
+	if (GetWindowSubclass(hWnd, ButtonSubclass, g_buttonSubclassID, NULL) == FALSE) {
+		DWORD_PTR pButtonData = (DWORD_PTR)calloc(0, sizeof(ButtonData));
+		SetWindowSubclass(hWnd, ButtonSubclass, g_buttonSubclassID, pButtonData);
+	}
+}
+
+static void PaintGroupbox(HWND hWnd, HDC hdc, ButtonData buttonData)
+{
+	const LONG_PTR nStyle = GetWindowLongPtr(hWnd, GWL_STYLE);
+	BOOL isDisabled = (nStyle & WS_DISABLED) == WS_DISABLED;
+	int iPartID = BP_GROUPBOX;
+	int iStateID = isDisabled ? GBS_DISABLED : GBS_NORMAL;
+
+	RECT rcClient = { 0 };
+	GetClientRect(hWnd, &rcClient);
+
+	rcClient.bottom -= 1;
+
+	RECT rcText = rcClient;
+	RECT rcBackground = rcClient;
+
+	HFONT hFont = NULL;
+	HFONT hOldFont = NULL;
+	HFONT hCreatedFont = NULL;
+	LOGFONT lf;
+	if (SUCCEEDED(GetThemeFont(buttonData.hTheme, hdc, iPartID, iStateID, TMT_FONT, &lf))) {
+		hCreatedFont = CreateFontIndirect(&lf);
+		hFont = hCreatedFont;
+	}
+
+	if (!hFont) {
+		hFont = (HFONT)SendMessage(hWnd, WM_GETFONT, 0, 0);
+	}
+
+	hOldFont = (HFONT)SelectObject(hdc, hFont);
+
+	wchar_t szText[256] = { '\0' };
+	GetWindowText(hWnd, szText, _countof(szText));
+
+	BOOL isCenter = (nStyle & BS_CENTER) == BS_CENTER;
+
+	if (szText[0]) {
+		SIZE textSize = { 0 };
+		GetTextExtentPoint32(hdc, szText, (int)wcslen(szText), &textSize);
+
+		int centerPosX = isCenter ? ((rcClient.right - rcClient.left - textSize.cx) / 2) : 7;
+
+		rcBackground.top += textSize.cy / 2;
+		rcText.left += centerPosX;
+		rcText.bottom = rcText.top + textSize.cy;
+		rcText.right = rcText.left + textSize.cx + 4;
+
+		ExcludeClipRect(hdc, rcText.left, rcText.top, rcText.right, rcText.bottom);
+	}
+	else {
+		SIZE textSize = { 0 };
+		GetTextExtentPoint32(hdc, L"M", 1, &textSize);
+		rcBackground.top += textSize.cy / 2;
+	}
+
+	RECT rcContent = rcBackground;
+	GetThemeBackgroundContentRect(buttonData.hTheme, hdc, BP_GROUPBOX, iStateID, &rcBackground, &rcContent);
+	ExcludeClipRect(hdc, rcContent.left, rcContent.top, rcContent.right, rcContent.bottom);
+
+	PaintRoundFrameRect(hdc, rcBackground, GetEdgePen(), 0, 0);
+
+	SelectClipRgn(hdc, NULL);
+
+	if (szText[0]) {
+		rcText.right -= 2;
+		rcText.left += 2;
+
+		DTTOPTS dtto;
+		ZeroMemory(&dtto, sizeof(DTTOPTS));
+		dtto.dwSize = sizeof(DTTOPTS);
+		dtto.dwFlags = DTT_TEXTCOLOR;
+		dtto.crText = isDisabled ? GetDisabledTextColor() : GetTextColorForDarkMode();
+
+		DWORD textFlags = isCenter ? DT_CENTER : DT_LEFT;
+
+		if (SendMessage(hWnd, WM_QUERYUISTATE, 0, 0) != (LRESULT)NULL) {
+			textFlags |= DT_HIDEPREFIX;
+		}
+
+		DrawThemeTextEx(buttonData.hTheme, hdc, BP_GROUPBOX, iStateID, szText, -1, textFlags | DT_SINGLELINE, &rcText, &dtto);
+	}
+
+	if (hCreatedFont) DeleteObject(hCreatedFont);
+	SelectObject(hdc, hOldFont);
+}
+
+static LRESULT CALLBACK GroupboxSubclass(
+	HWND hWnd,
+	UINT uMsg,
+	WPARAM wParam,
+	LPARAM lParam,
+	UINT_PTR uIdSubclass,
+	DWORD_PTR dwRefData
+)
+{
+	ButtonData* pButtonData = (ButtonData*)dwRefData;
+
+	switch (uMsg) {
+	case WM_NCDESTROY:
+	{
+		RemoveWindowSubclass(hWnd, ButtonSubclass, uIdSubclass);
+		if (pButtonData->hTheme) {
+			CloseThemeData(pButtonData->hTheme);
+		}
+		free(pButtonData);
+		break;
+	}
+
+	case WM_ERASEBKGND:
+	{
+		if (IsDarkModeEnabled()) {
+			if (pButtonData->hTheme == NULL) {
+				pButtonData->hTheme = OpenThemeData(hWnd, VSCLASS_BUTTON);
+			}
+
+			if (pButtonData->hTheme) {
+				return TRUE;
+			}
+		}
+		break;
+	}
+
+	case WM_DPICHANGED:
+	case WM_THEMECHANGED:
+	{
+		if (pButtonData->hTheme) {
+			CloseThemeData(pButtonData->hTheme);
+		}
+		break;
+	}
+
+	case WM_PRINTCLIENT:
+	case WM_PAINT:
+	{
+		if (IsDarkModeEnabled()) {
+			if (pButtonData->hTheme == NULL) {
+				pButtonData->hTheme = OpenThemeData(hWnd, VSCLASS_BUTTON);
+				if (pButtonData->hTheme == NULL) {
+					break;
+				}
+			}
+			PAINTSTRUCT ps;
+			ZeroMemory(&ps, sizeof(PAINTSTRUCT));
+			HDC hdc = (HDC)wParam;
+			if (!hdc) {
+				hdc = BeginPaint(hWnd, &ps);
+			}
+
+			PaintGroupbox(hWnd, hdc, *pButtonData);
+
+			if (ps.hdc) {
+				EndPaint(hWnd, &ps);
+			}
+
+			return 0;
+		}
+		break;
+	}
+
+	case WM_ENABLE:
+	{
+		RedrawWindow(hWnd, NULL, NULL, RDW_INVALIDATE);
+		break;
+	}
+	}
+	return DefSubclassProc(hWnd, uMsg, wParam, lParam);
+}
+
+static void SubclassGroupboxControl(HWND hWnd)
+{
+	if (GetWindowSubclass(hWnd, GroupboxSubclass, g_groupboxSubclassID, NULL) == FALSE) {
+		DWORD_PTR pButtonData = (DWORD_PTR)calloc(1, sizeof(ButtonData));
+		SetWindowSubclass(hWnd, GroupboxSubclass, g_groupboxSubclassID, pButtonData);
+	}
+}
+
+/*
+ * Toolbar section
+ */
+
+static UINT_PTR g_windowNotifySubclassID = 42;
+
+static LRESULT DarkToolBarNotifyCustomDraw(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
+{
+	LPNMTBCUSTOMDRAW lpnmtbcd = (LPNMTBCUSTOMDRAW)lParam;
+	static int roundCornerValue = 0;
+
+	switch (lpnmtbcd->nmcd.dwDrawStage) {
+	case CDDS_PREPAINT:
+	{
+		LRESULT lr = CDRF_DODEFAULT;
+		if (IsDarkModeEnabled()) {
+			if (IsAtLeastWin11()) {
+				roundCornerValue = 5;
+			}
+
+			FillRect(lpnmtbcd->nmcd.hdc, &lpnmtbcd->nmcd.rc, GetBackgroundBrush());
+			lr |= CDRF_NOTIFYITEMDRAW;
+		}
+		return lr;
+	}
+
+	case CDDS_ITEMPREPAINT:
+	{
+		lpnmtbcd->hbrMonoDither = GetBackgroundBrush();
+		lpnmtbcd->hbrLines = GetEdgeBrush();
+		lpnmtbcd->hpenLines = GetEdgePen();
+		lpnmtbcd->clrText = GetTextColorForDarkMode();
+		lpnmtbcd->clrTextHighlight = GetTextColorForDarkMode();
+		lpnmtbcd->clrBtnFace = GetBackgroundColor();
+		lpnmtbcd->clrBtnHighlight = GetControlBackgroundColor();
+		lpnmtbcd->clrHighlightHotTrack = GetHotBackgroundColor();
+		lpnmtbcd->nStringBkMode = TRANSPARENT;
+		lpnmtbcd->nHLStringBkMode = TRANSPARENT;
+
+		if ((lpnmtbcd->nmcd.uItemState & CDIS_HOT) == CDIS_HOT) {
+			HBRUSH holdBrush = (HBRUSH)SelectObject(lpnmtbcd->nmcd.hdc, GetHotBackgroundBrush());
+			HPEN holdPen = (HPEN)SelectObject(lpnmtbcd->nmcd.hdc, GetHotEdgePen());
+			RoundRect(lpnmtbcd->nmcd.hdc, lpnmtbcd->nmcd.rc.left, lpnmtbcd->nmcd.rc.top, lpnmtbcd->nmcd.rc.right, lpnmtbcd->nmcd.rc.bottom, roundCornerValue, roundCornerValue);
+			SelectObject(lpnmtbcd->nmcd.hdc, holdBrush);
+			SelectObject(lpnmtbcd->nmcd.hdc, holdPen);
+
+			lpnmtbcd->nmcd.uItemState &= ~(CDIS_CHECKED | CDIS_HOT);
+		}
+		else if ((lpnmtbcd->nmcd.uItemState & CDIS_CHECKED) == CDIS_CHECKED) {
+			HBRUSH holdBrush = (HBRUSH)SelectObject(lpnmtbcd->nmcd.hdc, GetControlBackgroundBrush());
+			HPEN holdPen = (HPEN)SelectObject(lpnmtbcd->nmcd.hdc, GetEdgePen());
+			RoundRect(lpnmtbcd->nmcd.hdc, lpnmtbcd->nmcd.rc.left, lpnmtbcd->nmcd.rc.top, lpnmtbcd->nmcd.rc.right, lpnmtbcd->nmcd.rc.bottom, roundCornerValue, roundCornerValue);
+			SelectObject(lpnmtbcd->nmcd.hdc, holdBrush);
+			SelectObject(lpnmtbcd->nmcd.hdc, holdPen);
+
+			lpnmtbcd->nmcd.uItemState &= ~CDIS_CHECKED;
+		}
+
+		LRESULT lr = TBCDRF_USECDCOLORS;
+		if ((lpnmtbcd->nmcd.uItemState & CDIS_SELECTED) == CDIS_SELECTED) {
+			lr |= TBCDRF_NOBACKGROUND;
+		}
+		return lr;
+	}
+
+	default:
+		break;
+	}
+	return DefSubclassProc(hWnd, uMsg, wParam, lParam);
+}
+
+static LRESULT DarkTrackBarNotifyCustomDraw(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
+{
+	LPNMCUSTOMDRAW lpnmcd = (LPNMCUSTOMDRAW)lParam;
+
+	switch (lpnmcd->dwDrawStage) {
+	case CDDS_PREPAINT:
+	{
+		if (IsDarkModeEnabled()) {
+			return CDRF_NOTIFYITEMDRAW;
+		}
+		return CDRF_DODEFAULT;
+	}
+
+	case CDDS_ITEMPREPAINT:
+	{
+		switch (lpnmcd->dwItemSpec) {
+		case TBCD_THUMB:
+		{
+			if ((lpnmcd->uItemState & CDIS_SELECTED) == CDIS_SELECTED) {
+				FillRect(lpnmcd->hdc, &lpnmcd->rc, GetControlBackgroundBrush());
+				return CDRF_SKIPDEFAULT;
+			}
+			break;
+		}
+
+		case TBCD_CHANNEL:
+		{
+			const LONG_PTR nStyle = GetWindowLongPtr(lpnmcd->hdr.hwndFrom, GWL_STYLE);
+			if ((nStyle & WS_DISABLED) == WS_DISABLED) {
+				FillRect(lpnmcd->hdc, &lpnmcd->rc, GetBackgroundBrush());
+				PaintRoundFrameRect(lpnmcd->hdc, lpnmcd->rc, GetEdgePen(), 0, 0);
+			}
+			else {
+				FillRect(lpnmcd->hdc, &lpnmcd->rc, GetControlBackgroundBrush());
+			}
+			return CDRF_SKIPDEFAULT;
+		}
+
+		default:
+			break;
+		}
+		break;
+	}
+
+	default:
+		break;
+	}
+	return DefSubclassProc(hWnd, uMsg, wParam, lParam);
+}
+
+static LRESULT CALLBACK WindowNotifySubclass(
+	HWND hWnd,
+	UINT uMsg,
+	WPARAM wParam,
+	LPARAM lParam,
+	UINT_PTR uIdSubclass,
+	DWORD_PTR dwRefData
+)
+{
+	(void)dwRefData;
+
+	switch (uMsg) {
+	case WM_NCDESTROY:
+	{
+		RemoveWindowSubclass(hWnd, WindowNotifySubclass, uIdSubclass);
+		break;
+	}
+
+	case WM_NOTIFY:
+	{
+		LPNMHDR nmhdr = (LPNMHDR)lParam;
+		WCHAR str[30] = { 0 };
+		GetClassName(nmhdr->hwndFrom, str, ARRAYSIZE(str));
+
+		switch (nmhdr->code) {
+		case NM_CUSTOMDRAW:
+		{
+			if (_wcsicmp(str, TOOLBARCLASSNAME) == 0) {
+				return DarkToolBarNotifyCustomDraw(hWnd, uMsg, wParam, lParam);
+			}
+			else if (_wcsicmp(str, TRACKBAR_CLASS) == 0) {
+				return DarkTrackBarNotifyCustomDraw(hWnd, uMsg, wParam, lParam);
+			}
+		}
+		break;
+		}
+		break;
+	}
+	}
+	return DefSubclassProc(hWnd, uMsg, wParam, lParam);
+}
+
+void SubclassNotifyCustomDraw(HWND hWnd)
+{
+	if (GetWindowSubclass(hWnd, WindowNotifySubclass, g_windowNotifySubclassID, NULL) == FALSE) {
+		SetWindowSubclass(hWnd, WindowNotifySubclass, g_windowNotifySubclassID, 0);
+	}
+}
+
+/*
+ * Status bar section
+ */
+
+typedef struct _StatusBarData {
+	HFONT hFont;
+} StatusBarData;
+
+const UINT_PTR g_statusBarSubclassID = 42;
+
+static void PaintStatusBar(HWND hWnd, HDC hdc, StatusBarData statusBarData)
+{
+	struct {
+		int horizontal;
+		int vertical;
+		int between;
+	} borders;
+	ZeroMemory(&borders, sizeof(borders));
+	SendMessage(hWnd, SB_GETBORDERS, 0, (LPARAM)&borders);
+
+	RECT rcClient = { 0,0,0,0 };
+	GetClientRect(hWnd, &rcClient);
+
+	HPEN holdPen = (HPEN)SelectObject(hdc, GetEdgePen());
+	HFONT holdFont = (HFONT)SelectObject(hdc, statusBarData.hFont);
+
+	SetBkMode(hdc, TRANSPARENT);
+	SetTextColor(hdc, GetTextColorForDarkMode());
+
+	FillRect(hdc, &rcClient, GetBackgroundBrush());
+
+	int nParts = (int)SendMessage(hWnd, SB_GETPARTS, 0, 0);
+	RECT rcPart = { 0 };
+	RECT rcIntersect = { 0 };
+	for (int i = 0; i < nParts; ++i) {
+		SendMessage(hWnd, SB_GETRECT, i, (LPARAM)&rcPart);
+		if (IntersectRect(&rcIntersect, &rcPart, &rcClient) == FALSE) {
+			continue;
+		}
+
+		if (i < nParts - 1) {
+			POINT edges[] = {
+				{rcPart.right - borders.between, rcPart.top + 1},
+				{rcPart.right - borders.between, rcPart.bottom - 3}
+			};
+			Polyline(hdc, edges, _countof(edges));
+		}
+
+		DWORD cchText = LOWORD(SendMessage(hWnd, SB_GETTEXTLENGTH, i, 0));
+		LPWSTR buffer = (LPWSTR)calloc(cchText, sizeof(WCHAR));
+		LRESULT lr = SendMessage(hWnd, SB_GETTEXT, i, (LPARAM)buffer);
+		BOOL ownerDraw = FALSE;
+		if (cchText == 0 && (lr & ~(SBT_NOBORDERS | SBT_POPOUT | SBT_RTLREADING)) != 0) {
+			ownerDraw = TRUE;
+		}
+
+		rcPart.left += borders.between;
+		rcPart.right -= borders.vertical;
+
+		if (ownerDraw) {
+			UINT id = GetDlgCtrlID(hWnd);
+			DRAWITEMSTRUCT dis = {
+				0
+				, 0
+				, (UINT)i
+				, ODA_DRAWENTIRE
+				, id
+				, hWnd
+				, hdc
+				, rcPart
+				, (ULONG_PTR)lr
+			};
+
+			SendMessage(GetParent(hWnd), WM_DRAWITEM, id, (LPARAM)&dis);
+		}
+		else {
+			if (buffer) {
+				DrawText(hdc, buffer, (int)cchText, &rcPart, DT_SINGLELINE | DT_VCENTER | DT_LEFT);
+			}
+		}
+		free(buffer);
+	}
+
+	POINT edgeHor[] = {
+		{rcClient.left, rcClient.top},
+		{rcClient.right, rcClient.top}
+	};
+	Polyline(hdc, edgeHor, _countof(edgeHor));
+
+	SelectObject(hdc, holdFont);
+	SelectObject(hdc, holdPen);
+}
+
+static LRESULT CALLBACK StatusBarSubclass(
+	HWND hWnd,
+	UINT uMsg,
+	WPARAM wParam,
+	LPARAM lParam,
+	UINT_PTR uIdSubclass,
+	DWORD_PTR dwRefData)
+{
+	StatusBarData* pStatusBarData = (StatusBarData*)dwRefData;
+
+	switch (uMsg) {
+	case WM_ERASEBKGND:
+	{
+		if (!IsDarkModeEnabled()) {
+			break;
+		}
+
+		RECT rcClient = { 0,0,0,0 };
+		GetClientRect(hWnd, &rcClient);
+		FillRect((HDC)wParam, &rcClient, GetBackgroundBrush());
+		return TRUE;
+	}
+
+	case WM_PAINT:
+	{
+		if (!IsDarkModeEnabled()) {
+			break;
+		}
+
+		PAINTSTRUCT ps;
+		HDC hdc = BeginPaint(hWnd, &ps);
+
+		PaintStatusBar(hWnd, hdc, *pStatusBarData);
+
+		EndPaint(hWnd, &ps);
+		return 0;
+	}
+
+	case WM_NCDESTROY:
+	{
+		RemoveWindowSubclass(hWnd, StatusBarSubclass, uIdSubclass);
+		if (pStatusBarData->hFont != NULL) {
+			DeleteObject(pStatusBarData->hFont);
+			pStatusBarData->hFont = NULL;
+		}
+		free(pStatusBarData);
+		break;
+	}
+
+	case WM_DPICHANGED:
+	case WM_THEMECHANGED:
+	{
+		if (pStatusBarData->hFont != NULL) {
+			DeleteObject(pStatusBarData->hFont);
+			pStatusBarData->hFont = NULL;
+		}
+
+		LOGFONT lf;
+		NONCLIENTMETRICS ncm;
+		ZeroMemory(&ncm, sizeof(NONCLIENTMETRICS));
+		ncm.cbSize = sizeof(NONCLIENTMETRICS);
+		if (SystemParametersInfo(SPI_GETNONCLIENTMETRICS, sizeof(NONCLIENTMETRICS), &ncm, 0) == TRUE) {
+			lf = ncm.lfStatusFont;
+			pStatusBarData->hFont = CreateFontIndirect(&lf);
+		}
+
+		if (uMsg != WM_THEMECHANGED) {
+			return 0;
+		}
+		break;
+	}
+	}
+	return DefSubclassProc(hWnd, uMsg, wParam, lParam);
+}
+
+void SubclassStatusBar(HWND hWnd)
+{
+	if (IsDarkModeEnabled() &&
+		GetWindowSubclass(hWnd, StatusBarSubclass, g_statusBarSubclassID, NULL) == FALSE)
+	{
+		StatusBarData* statusBarData = (StatusBarData*)malloc(sizeof(StatusBarData));
+		if (statusBarData == NULL) {
+			return; // something wrong happened
+		}
+
+		LOGFONT lf;
+		NONCLIENTMETRICS ncm;
+		ZeroMemory(&ncm, sizeof(NONCLIENTMETRICS));
+		ncm.cbSize = sizeof(NONCLIENTMETRICS);
+		if (SystemParametersInfo(SPI_GETNONCLIENTMETRICS, sizeof(NONCLIENTMETRICS), &ncm, 0) == TRUE) {
+			lf = ncm.lfStatusFont;
+			statusBarData->hFont = CreateFontIndirect(&lf);
+		}
+		DWORD_PTR pStatusBarData = (DWORD_PTR)statusBarData;
+		SetWindowSubclass(hWnd, StatusBarSubclass, g_statusBarSubclassID, pStatusBarData);
+	}
+}
+
+/*
+ * Progress bar section
+ */
+
+typedef struct _ProgressBarData {
+	HTHEME hTheme;
+	int iStateID;
+} ProgressBarData;
+
+const UINT_PTR g_progressBarSubclassID = 42;
+
+static void GetProgressBarRects(HWND hWnd, RECT* rcEmpty, RECT* rcFilled)
+{
+	int pos = (int)SendMessage(hWnd, PBM_GETPOS, 0, 0);
+
+	PBRANGE range = { 0, 0 };
+	SendMessage(hWnd, PBM_GETRANGE, TRUE, (LPARAM)&range);
+	int min = range.iLow;
+	int max = range.iHigh;
+
+	int currPos = pos - min;
+	if (currPos != 0) {
+		int totalWidth = rcEmpty->right - rcEmpty->left;
+		rcFilled->left = rcEmpty->left;
+		rcFilled->top = rcEmpty->top;
+		rcFilled->bottom = rcEmpty->bottom;
+		rcFilled->right = rcEmpty->left + (int)((double)(currPos) / (max - min) * totalWidth);
+
+		rcEmpty->left = rcFilled->right; // to avoid painting under filled part
+	}
+}
+
+static void PaintProgressBar(HWND hWnd, HDC hdc, ProgressBarData progressBarData)
+{
+	RECT rcClient = { 0 };
+	GetClientRect(hWnd, &rcClient);
+
+	PaintRoundFrameRect(hdc, rcClient, GetEdgePen(), 0, 0);
+
+	InflateRect(&rcClient, -1, -1);
+	rcClient.left = 1;
+
+	RECT rcFill = { 0 };
+	GetProgressBarRects(hWnd, &rcClient, &rcFill);
+	DrawThemeBackground(progressBarData.hTheme, hdc, PP_FILL, progressBarData.iStateID, &rcFill, NULL);
+	FillRect(hdc, &rcClient, GetControlBackgroundBrush());
+}
+
+static LRESULT CALLBACK ProgressBarSubclass(
+	HWND hWnd,
+	UINT uMsg,
+	WPARAM wParam,
+	LPARAM lParam,
+	UINT_PTR uIdSubclass,
+	DWORD_PTR dwRefData
+)
+{
+	ProgressBarData* pProgressBarData = (ProgressBarData*)dwRefData;
+
+	switch (uMsg) {
+	case WM_NCDESTROY:
+	{
+		RemoveWindowSubclass(hWnd, ButtonSubclass, uIdSubclass);
+		if (pProgressBarData->hTheme) {
+			CloseThemeData(pProgressBarData->hTheme);
+		}
+		free(pProgressBarData);
+		break;
+	}
+
+	case WM_ERASEBKGND:
+	{
+		if (IsDarkModeEnabled()) {
+			if (pProgressBarData->hTheme == NULL) {
+				pProgressBarData->hTheme = OpenThemeData(hWnd, VSCLASS_PROGRESS);
+			}
+
+			if (pProgressBarData->hTheme) {
+				return TRUE;
+			}
+		}
+		break;
+	}
+
+	case WM_DPICHANGED:
+	case WM_THEMECHANGED:
+	{
+		if (pProgressBarData->hTheme) {
+			CloseThemeData(pProgressBarData->hTheme);
+		}
+		break;
+	}
+
+	case PBM_SETSTATE:
+	{
+		switch (wParam) {
+		case PBST_NORMAL:
+			// PBFS_PARTIAL for cyan color
+			pProgressBarData->iStateID = PBFS_NORMAL; // green
+			break;
+		case PBST_ERROR:
+			pProgressBarData->iStateID = PBFS_ERROR; // red
+			break;
+		case PBST_PAUSED:
+			pProgressBarData->iStateID = PBFS_PAUSED; // yellow
+			break;
+		}
+		break;
+	}
+
+	case WM_PAINT:
+	{
+		if (!IsDarkModeEnabled()) {
+			break;
+		}
+
+		if (pProgressBarData->hTheme == NULL) {
+			pProgressBarData->hTheme = OpenThemeData(hWnd, VSCLASS_PROGRESS);
+			if (pProgressBarData->hTheme == NULL) {
+				break;
+			}
+		}
+
+		PAINTSTRUCT ps;
+		HDC hdc = BeginPaint(hWnd, &ps);
+
+		PaintProgressBar(hWnd, hdc, *pProgressBarData);
+
+		EndPaint(hWnd, &ps);
+
+		return 0;
+		
+	}
+	}
+	return DefSubclassProc(hWnd, uMsg, wParam, lParam);
+}
+
+void SubclassProgressBarControl(HWND hWnd)
+{
+	if (IsDarkModeEnabled() &&
+		GetWindowSubclass(hWnd, ProgressBarSubclass, g_progressBarSubclassID, NULL) == FALSE) {
+		DWORD_PTR pProgressBarData = (DWORD_PTR)calloc(1, sizeof(ProgressBarData));
+		SetWindowSubclass(hWnd, ProgressBarSubclass, g_progressBarSubclassID, pProgressBarData);
+	}
+}
+
+/*
+ * Static text section
+ */
+
+typedef struct _StaticTextData {
+	BOOL isDisabled;
+} StaticTextData;
+
+const UINT_PTR g_staticTextSubclassID = 42;
+
+static LRESULT CALLBACK StaticTextSubclass(
+	HWND hWnd,
+	UINT uMsg,
+	WPARAM wParam,
+	LPARAM lParam,
+	UINT_PTR uIdSubclass,
+	DWORD_PTR dwRefData
+)
+{
+	StaticTextData* pStaticTextData = (StaticTextData*)dwRefData;
+
+	switch (uMsg) {
+	case WM_NCDESTROY:
+	{
+		RemoveWindowSubclass(hWnd, StaticTextSubclass, uIdSubclass);
+		free(pStaticTextData);
+		break;
+	}
+
+	case WM_ENABLE:
+	{
+		pStaticTextData->isDisabled = (wParam == FALSE);
+
+		const LONG_PTR nStyle = GetWindowLongPtr(hWnd, GWL_STYLE);
+		if (pStaticTextData->isDisabled)
+			SetWindowLongPtr(hWnd, GWL_STYLE, nStyle & ~WS_DISABLED);
+
+		RECT rcClient = { 0 };
+		GetClientRect(hWnd, &rcClient);
+		MapWindowPoints(hWnd, GetParent(hWnd), (LPPOINT)&rcClient, 2);
+		RedrawWindow(GetParent(hWnd), &rcClient, NULL, RDW_INVALIDATE | RDW_UPDATENOW);
+
+		if (pStaticTextData->isDisabled)
+			SetWindowLongPtr(hWnd, GWL_STYLE, nStyle | WS_DISABLED);
+
+		return 0;
+	}
+	}
+	return DefSubclassProc(hWnd, uMsg, wParam, lParam);
+}
+
+static void SubclassStaticText(HWND hWnd)
+{
+	if (GetWindowSubclass(hWnd, StaticTextSubclass, g_staticTextSubclassID, NULL) == FALSE) {
+		DWORD_PTR pStaticTextData = (DWORD_PTR)calloc(1, sizeof(StaticTextData));
+		SetWindowSubclass(hWnd, StaticTextSubclass, g_staticTextSubclassID, pStaticTextData);
+	}
+}
+
+/*
+ * Ctl color messages section
+ */
+
+const UINT_PTR g_WindowCtlColorSubclassID = 42;
+
+static LRESULT OnCtlColor(HDC hdc)
+{
+	if (!IsDarkModeEnabled()) {
+		return FALSE;
+	}
+
+	SetTextColor(hdc, GetTextColorForDarkMode());
+	SetBkColor(hdc, GetBackgroundColor());
+	return (LRESULT)GetBackgroundBrush();
+}
+
+static LRESULT OnCtlColorStatic(WPARAM wParam, LPARAM lParam)
+{
+	if (!IsDarkModeEnabled()) {
+		return FALSE;
+	}
+
+	HDC hdc = (HDC)wParam;
+	HWND hWnd = (HWND)lParam;
+	WCHAR str[30] = { 0 };
+	GetClassName(hWnd, str, ARRAYSIZE(str));
+
+	if (_wcsicmp(str, WC_STATIC) == 0) {
+		const LONG_PTR nStyle = GetWindowLongPtr(hWnd, GWL_STYLE);
+		if ((nStyle & SS_NOTIFY) == SS_NOTIFY) {
+			DWORD_PTR dwRefData = 0;
+			COLORREF cText = cAccent;
+			if (GetWindowSubclass(hWnd, StaticTextSubclass, g_staticTextSubclassID, &dwRefData) == TRUE) {
+				StaticTextData* pStaticTextData = (StaticTextData*)dwRefData;
+				if (pStaticTextData->isDisabled)
+					cText = GetDisabledTextColor();
+			}
+			SetTextColor(hdc, cText);
+			SetBkColor(hdc, GetBackgroundColor());
+			return (LRESULT)GetBackgroundBrush();
+		}
+	}
+	// read-only WC_EDIT
+	return OnCtlColor(hdc);
+}
+
+static LRESULT OnCtlColorSofter(HDC hdc)
+{
+	if (!IsDarkModeEnabled()) {
+		return FALSE;
+	}
+
+	SetTextColor(hdc, GetTextColorForDarkMode());
+	SetBkColor(hdc, GetControlBackgroundColor());
+	return (LRESULT)GetControlBackgroundBrush();
+}
+
+
+static INT_PTR OnCtlColorListbox(WPARAM wParam, LPARAM lParam)
+{
+	HDC hdc = (HDC)wParam;
+	HWND hWnd = (HWND)lParam;
+
+	const LONG_PTR nStyle = GetWindowLongPtr(hWnd, GWL_STYLE);
+	BOOL isComboBox = (nStyle & LBS_COMBOBOX) == LBS_COMBOBOX;
+	if ((!isComboBox || !isDarkEnabled) && IsWindowEnabled(hWnd)) {
+		return (INT_PTR)OnCtlColorSofter(hdc);
+	}
+	return (INT_PTR)OnCtlColor(hdc);
+}
+
+static LRESULT CALLBACK WindowCtlColorSubclass(
+	HWND hWnd,
+	UINT uMsg,
+	WPARAM wParam,
+	LPARAM lParam,
+	UINT_PTR uIdSubclass,
+	DWORD_PTR dwRefData
+)
+{
+	(void)dwRefData;
+
+	switch (uMsg) {
+	case WM_ERASEBKGND:
+	{
+		if (!IsDarkModeEnabled()) {
+			break;
+		}
+
+		RECT rcClient = { 0,0,0,0 };
+		GetClientRect(hWnd, &rcClient);
+		FillRect((HDC)wParam, &rcClient, GetBackgroundBrush());
+		return TRUE;
+	}
+
+	case WM_NCDESTROY:
+	{
+		RemoveWindowSubclass(hWnd, WindowCtlColorSubclass, uIdSubclass);
+		break;
+	}
+
+	case WM_CTLCOLOREDIT:
+	{
+		if (IsDarkModeEnabled()) {
+			return OnCtlColorSofter((HDC)wParam);
+		}
+		break;
+	}
+
+	case WM_CTLCOLORLISTBOX:
+	{
+		if (IsDarkModeEnabled()) {
+			return OnCtlColorListbox(wParam, lParam);
+		}
+		break;
+	}
+
+	case WM_CTLCOLORDLG:
+	{
+		if (IsDarkModeEnabled()) {
+			return OnCtlColor((HDC)wParam);
+		}
+		break;
+	}
+
+	case WM_CTLCOLORSTATIC:
+	{
+		if (IsDarkModeEnabled()) {
+			return OnCtlColorStatic(wParam, lParam);
+		}
+		break;
+	}
+
+	case WM_PRINTCLIENT:
+	{
+		if (IsDarkModeEnabled()) {
+			return TRUE;
+		}
+		break;
+	}
+	}
+	return DefSubclassProc(hWnd, uMsg, wParam, lParam);
+}
+
+void SubclassCtlColor(HWND hWnd)
+{
+	if (GetWindowSubclass(hWnd, WindowCtlColorSubclass, g_WindowCtlColorSubclassID, NULL) == FALSE) {
+		SetWindowSubclass(hWnd, WindowCtlColorSubclass, g_WindowCtlColorSubclassID, 0);
+	}
+}
+
+/*
+ * Dark mode for child controls
+ */
+
+static BOOL CALLBACK DarkModeForChildCallback(HWND hWnd, LPARAM lParam)
+{
+	(void)lParam;
+
+	WCHAR str[30] = { 0 };
+	GetClassName(hWnd, str, ARRAYSIZE(str));
+
+	if (_wcsicmp(str, WC_STATIC) == 0) {
+		const LONG_PTR nStyle = GetWindowLongPtr(hWnd, GWL_STYLE);
+		if ((nStyle & SS_NOTIFY) == SS_NOTIFY) {
+			SubclassStaticText(hWnd);
+		}
+	}
+	else if (_wcsicmp(str, WC_BUTTON) == 0) {
+		const LONG_PTR nButtonStyle = GetWindowLongPtr(hWnd, GWL_STYLE);
+		switch (nButtonStyle & BS_TYPEMASK) {
+		case BS_CHECKBOX:
+		case BS_AUTOCHECKBOX:
+		case BS_3STATE:
+		case BS_AUTO3STATE:
+		case BS_RADIOBUTTON:
+		case BS_AUTORADIOBUTTON:
+		{
+			if ((nButtonStyle & BS_PUSHLIKE) == BS_PUSHLIKE) {
+				SetDarkTheme(hWnd);
+				break;
+			}
+
+			if (IsAtLeastWin11()) {
+				SetDarkTheme(hWnd);
+			}
+			SubclassButtonControl(hWnd);
+			break;
+		}
+
+		case BS_GROUPBOX:
+		{
+			SubclassGroupboxControl(hWnd);
+			break;
+		}
+
+		case BS_PUSHBUTTON:
+		case BS_DEFPUSHBUTTON:
+		case BS_SPLITBUTTON:
+		case BS_DEFSPLITBUTTON:
+		{
+			SetDarkTheme(hWnd);
+			break;
+		}
+
+		default:
+		{
+			break;
+		}
+		}
+	}
+	else if (_wcsicmp(str, WC_COMBOBOX) == 0) {
+		SetWindowTheme(hWnd, IsDarkModeEnabled() ? L"DarkMode_CFD" : NULL, NULL);
+	}
+	else if (_wcsicmp(str, TOOLBARCLASSNAME) == 0) {
+		HWND hTips = (HWND)SendMessage(hWnd, TB_GETTOOLTIPS, 0, 0);
+		if (hTips != NULL) {
+			SetDarkTheme(hTips);
+		}
+	}
+	else if (_wcsicmp(str, WC_EDIT) == 0) {
+		const LONG_PTR nStyle = GetWindowLongPtr(hWnd, GWL_STYLE);
+		if (((nStyle & WS_VSCROLL) == WS_VSCROLL) || ((nStyle & WS_HSCROLL) == WS_HSCROLL)) {
+			SetDarkTheme(hWnd);
+			SetWindowLongPtr(hWnd, GWL_STYLE, nStyle | WS_BORDER);
+			const LONG_PTR nExStyle = GetWindowLongPtr(hWnd, GWL_EXSTYLE);
+			SetWindowLongPtr(hWnd, GWL_EXSTYLE, nExStyle & ~WS_EX_CLIENTEDGE);
+		}
+		else {
+			SetWindowTheme(hWnd, IsDarkModeEnabled() ? L"DarkMode_CFD" : NULL, NULL);
+		}
+	}
+	else if (_wcsicmp(str, RICHEDIT_CLASS) == 0) {
+		const LONG_PTR nExStyle = GetWindowLongPtr(hWnd, GWL_EXSTYLE);
+		BOOL hasStaticEdge = (nExStyle & WS_EX_STATICEDGE) == WS_EX_STATICEDGE;
+		COLORREF cBg = IsDarkModeEnabled() ? (hasStaticEdge ? GetControlBackgroundColor() : GetBackgroundColor()) : GetSysColor(COLOR_BTNFACE);
+		SendMessage(hWnd, EM_SETBKGNDCOLOR, 0, (LPARAM)cBg);
+		CHARFORMATW cf;
+		ZeroMemory(&cf, sizeof(CHARFORMATW));
+		cf.cbSize = sizeof(CHARFORMATW);
+		cf.dwMask = CFM_COLOR;
+		cf.crTextColor = IsDarkModeEnabled() ? GetTextColorForDarkMode() : GetSysColor(COLOR_WINDOWTEXT);
+		SendMessage(hWnd, EM_SETCHARFORMAT, SCF_DEFAULT, (LPARAM)&cf);
+		SetWindowTheme(hWnd, NULL, IsDarkModeEnabled() ? L"DarkMode_Explorer::ScrollBar" : NULL);
+		const LONG_PTR nStyle = GetWindowLongPtr(hWnd, GWL_STYLE);
+		SetWindowLongPtr(hWnd, GWL_STYLE, nStyle | WS_BORDER);
+		SetWindowLongPtr(hWnd, GWL_EXSTYLE, nExStyle & ~WS_EX_STATICEDGE);
+	}
+
+	return TRUE;
+}
+
+void SetDarkModeForChild(HWND hParent)
+{
+	if (IsDarkModeEnabled()) {
+		EnumChildWindows(hParent, DarkModeForChildCallback, (LPARAM)NULL);
+	}
+}

--- a/src/darkmode.h
+++ b/src/darkmode.h
@@ -20,7 +20,7 @@
 #pragma once
 
 // WinAPI
-#include <Windows.h>
+#include <windows.h>
 
 BOOL IsDarkModeEnabled(void);
 BOOL GetDarkModeFromReg(void);

--- a/src/darkmode.h
+++ b/src/darkmode.h
@@ -23,7 +23,6 @@
 #include <Windows.h>
 
 BOOL IsDarkModeEnabled(void);
-BOOL IsAtLeastWin10Build(DWORD buildNumber);
 BOOL GetDarkModeFromReg(void);
 void InitDarkMode(HWND hWnd);
 void SetDarkTitleBar(HWND hWnd);

--- a/src/darkmode.h
+++ b/src/darkmode.h
@@ -31,7 +31,7 @@ BOOL InitAccentColor(void);
 BOOL ChangeIconColor(HICON* hIcon, COLORREF newColor);
 COLORREF GetTextColorForDarkMode(void);
 COLORREF GetDisabledTextColor(void);
-COLORREF GetControlBackgroundColor(void);
+COLORREF GetCtrlBackgroundColor(void);
 COLORREF GetEdgeColor(void);
 void DestroyDarkModeGDIObjects(void);
 void SubclassCtlColor(HWND hWnd);

--- a/src/darkmode.h
+++ b/src/darkmode.h
@@ -1,0 +1,60 @@
+/*
+ * Rufus: The Reliable USB Formatting Utility
+ * Dark mode for Rufus
+ * Copyright © 2025 ozone10
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+// WinAPI
+#include <Windows.h>
+
+BOOL IsDarkModeEnabled(void);
+BOOL IsAtLeastWin10Build(DWORD buildNumber);
+BOOL GetDarkModeFromReg(void);
+void InitDarkMode(HWND hWnd);
+void SetDarkTitleBar(HWND hWnd);
+void SetDarkTheme(HWND hWnd);
+BOOL InitAccentColor(void);
+BOOL ChangeIconColor(HICON* hIcon, COLORREF newColor);
+COLORREF GetTextColorForDarkMode(void);
+COLORREF GetDisabledTextColor(void);
+COLORREF GetControlBackgroundColor(void);
+COLORREF GetEdgeColor(void);
+void DestroyDarkModeGDIObjects(void);
+void SubclassCtlColor(HWND hWnd);
+void SubclassNotifyCustomDraw(HWND hWnd);
+void SubclassStatusBar(HWND hWnd);
+void SubclassProgressBarControl(HWND hWnd);
+void SetDarkModeForChild(HWND hParent);
+
+static __inline void SetDarkModeForDlg(HWND hWnd)
+{
+	if (IsDarkModeEnabled()) {
+		SetDarkTitleBar(hWnd);
+		SubclassCtlColor(hWnd);
+	}
+}
+
+static __inline void InitAndSetDarkModeForMainDlg(HWND hWnd)
+{
+	if (GetDarkModeFromReg()) {
+		InitDarkMode(hWnd);
+		InitAccentColor();
+		SetDarkModeForDlg(hWnd);
+		SubclassNotifyCustomDraw(hWnd);
+	}
+}

--- a/src/hash.c
+++ b/src/hash.c
@@ -78,6 +78,8 @@
 #include "msapi_utf8.h"
 #include "localization.h"
 
+#include "darkmode.h"
+
 #if (defined(_M_IX86) || defined(_M_X64) || defined(__i386__) || defined(__i386) || \
      defined(_X86_) || defined(__I86__) || defined(__x86_64__))
 #define CPU_X86_SHA1_ACCELERATION       1
@@ -1894,6 +1896,7 @@ INT_PTR CALLBACK HashCallback(HWND hDlg, UINT message, WPARAM wParam, LPARAM lPa
 
 	switch (message) {
 	case WM_INITDIALOG:
+		SetDarkModeForDlg(hDlg);
 		apply_localization(IDD_HASH, hDlg);
 		if (hFont == NULL) {
 			hDC = GetDC(hDlg);
@@ -1941,6 +1944,7 @@ INT_PTR CALLBACK HashCallback(HWND hDlg, UINT message, WPARAM wParam, LPARAM lPa
 			for (i = (int)strlen(image_path); (i > 0) && (image_path[i] != '\\'); i--);
 			SetWindowTextU(hDlg, &image_path[i + 1]);
 		}
+		SetDarkModeForChild(hDlg);
 		// Set focus on the OK button
 		SendMessage(hDlg, WM_NEXTDLGCTL, (WPARAM)GetDlgItem(hDlg, IDOK), TRUE);
 		CenterDialog(hDlg, NULL);

--- a/src/rufus.c
+++ b/src/rufus.c
@@ -57,6 +57,8 @@
 #include "../res/grub/grub_version.h"
 #include "../res/grub2/grub2_version.h"
 
+#include "darkmode.h"
+
 enum bootcheck_return {
 	BOOTCHECK_PROCEED = 0,
 	BOOTCHECK_CANCEL = -1,
@@ -957,6 +959,7 @@ BOOL CALLBACK LogCallback(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam)
 	EXT_DECL(log_ext, "rufus.log", __VA_GROUP__("*.log"), __VA_GROUP__("Rufus log"));
 	switch (message) {
 	case WM_INITDIALOG:
+		SetDarkModeForDlg(hDlg);
 		apply_localization(IDD_LOG, hDlg);
 		hLog = GetDlgItem(hDlg, IDC_LOG_EDIT);
 
@@ -984,6 +987,7 @@ BOOL CALLBACK LogCallback(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam)
 		style = GetWindowLongPtr(hLog, GWL_STYLE);
 		style &= ~(ES_RIGHT);
 		SetWindowLongPtr(hLog, GWL_STYLE, style);
+		SetDarkModeForChild(hDlg);
 		break;
 	case WM_NCDESTROY:
 		safe_delete_object(hf);
@@ -2760,6 +2764,7 @@ static INT_PTR CALLBACK MainCallback(HWND hDlg, UINT message, WPARAM wParam, LPA
 		break;
 
 	case WM_INITDIALOG:
+		InitAndSetDarkModeForMainDlg(hDlg);
 		// Make sure fScale is set before the first call to apply localization, so that move/resize scale appropriately
 		hDC = GetDC(hDlg);
 		fScale = GetDeviceCaps(hDC, LOGPIXELSX) / 96.0f;
@@ -2806,6 +2811,9 @@ static INT_PTR CALLBACK MainCallback(HWND hDlg, UINT message, WPARAM wParam, LPA
 		MessageBoxA(NULL, "This is a Test version of " APPLICATION_NAME " - It is meant to be used for "
 			"testing ONLY and should NOT be distributed as a release.", "TEST VERSION", MSG_INFO);
 #endif
+		SetDarkModeForChild(hDlg);
+		SubclassStatusBar(hStatus);
+		SetHyperLinkFont(GetDlgItem(hDlg, IDS_CSM_HELP_TXT), (HDC)wParam, &hHyperlinkFont, FALSE);
 		// Let's not take any risk: Ask Windows to redraw the whole dialog before we exit init
 		RedrawWindow(hMainDialog, NULL, NULL, RDW_ALLCHILDREN | RDW_UPDATENOW);
 		InvalidateRect(hMainDialog, NULL, TRUE);
@@ -2824,12 +2832,12 @@ static INT_PTR CALLBACK MainCallback(HWND hDlg, UINT message, WPARAM wParam, LPA
 			SetBkMode(pDI->hDC, TRANSPARENT);
 			switch (pDI->itemID) {
 			case SB_SECTION_LEFT:
-				SetTextColor(pDI->hDC, GetSysColor(COLOR_BTNTEXT));
+				SetTextColor(pDI->hDC, IsDarkModeEnabled() ? GetTextColorForDarkMode() : GetSysColor(COLOR_BTNTEXT));
 				DrawTextExU(pDI->hDC, szStatusMessage, -1, &pDI->rcItem,
 					DT_LEFT | DT_END_ELLIPSIS | DT_PATH_ELLIPSIS, NULL);
 				return (INT_PTR)TRUE;
 			case SB_SECTION_RIGHT:
-				SetTextColor(pDI->hDC, GetSysColor(COLOR_3DSHADOW));
+				SetTextColor(pDI->hDC, IsDarkModeEnabled() ? GetDisabledTextColor() : GetSysColor(COLOR_3DSHADOW));
 				DrawTextExA(pDI->hDC, szTimer, -1, &pDI->rcItem, DT_LEFT, NULL);
 				return (INT_PTR)TRUE;
 			}
@@ -2846,7 +2854,6 @@ static INT_PTR CALLBACK MainCallback(HWND hDlg, UINT message, WPARAM wParam, LPA
 		if ((HWND)lParam != GetDlgItem(hDlg, IDS_CSM_HELP_TXT))
 			return FALSE;
 		SetBkMode((HDC)wParam, TRANSPARENT);
-		CreateStaticFont((HDC)wParam, &hHyperlinkFont, FALSE);
 		SelectObject((HDC)wParam, hHyperlinkFont);
 		SetTextColor((HDC)wParam, TOOLBAR_ICON_COLOR);
 		return (INT_PTR)GetSysColorBrush(COLOR_BTNFACE);
@@ -4189,6 +4196,7 @@ out:
 			uprintf("Could not delete '%s': %s", loc_file, WindowsErrorString());
 	}
 	DestroyAllTooltips();
+	DestroyDarkModeGDIObjects();
 	ClrAlertPromptHook();
 	exit_localization();
 	safe_free(image_path);

--- a/src/rufus.h
+++ b/src/rufus.h
@@ -786,6 +786,7 @@ extern void ResizeMoveCtrl(HWND hDlg, HWND hCtrl, int dx, int dy, int dw, int dh
 extern void ResizeButtonHeight(HWND hDlg, int id);
 extern void CreateStatusBar(HFONT* hFont);
 extern void CreateStaticFont(HDC hDC, HFONT* hFont, BOOL underlined);
+extern void SetHyperLinkFont(HWND hWnd, HDC hDC, HFONT* hFont, BOOL underlined);
 extern void SetTitleBarIcon(HWND hDlg);
 extern BOOL CreateTaskbarList(void);
 extern BOOL SetTaskbarProgressState(TASKBAR_PROGRESS_FLAGS tbpFlags);
@@ -955,8 +956,13 @@ out:
 #define PF_TYPE_DECL(api, ret, proc, args)	PF_TYPE(api, ret, proc, args); PF_DECL(proc)
 #define PF_INIT(proc, name)					if (pf##proc == NULL) pf##proc = \
 	(proc##_t) GetProcAddress(GetLibraryHandle(#name), #proc)
+#define PF_INIT_ID(proc, name, id)			if (pf##proc == NULL) pf##proc = \
+	(proc##_t) GetProcAddress(GetLibraryHandle(#name), MAKEINTRESOURCEA(id))
 #define PF_INIT_OR_OUT(proc, name)			do {PF_INIT(proc, name);         \
 	if (pf##proc == NULL) {uprintf("Unable to locate %s() in '%s.dll': %s",  \
+	#proc, #name, WindowsErrorString()); goto out;} } while(0)
+#define PF_INIT_ID_OR_OUT(proc, name, id)	do {PF_INIT_ID(proc, name, id);  \
+	if (pf##proc == NULL) {uprintf("Unable to locate %s() in %s.dll: %s\n",  \
 	#proc, #name, WindowsErrorString()); goto out;} } while(0)
 #define PF_INIT_OR_SET_STATUS(proc, name)	do {PF_INIT(proc, name);         \
 	if ((pf##proc == NULL) && (NT_SUCCESS(status))) status = STATUS_PROCEDURE_NOT_FOUND; } while(0)

--- a/src/rufus.rc
+++ b/src/rufus.rc
@@ -211,7 +211,7 @@ CAPTION "Update policy and settings"
 FONT 9, "Segoe UI Symbol", 400, 0, 0x0
 BEGIN
     ICON            IDI_ICON,IDC_ABOUT_ICON,11,8,20,20
-    CONTROL         "",IDC_POLICY,"RichEdit20W",WS_VSCROLL | WS_TABSTOP | 0x804,46,8,235,132,WS_EX_STATICEDGE
+    CONTROL         "",IDC_POLICY,"RichEdit20W",WS_VSCROLL | WS_TABSTOP | 0x804,45,8,236,132,WS_EX_STATICEDGE
     GROUPBOX        "Settings",IDS_UPDATE_SETTINGS_GRP,45,145,165,46
     LTEXT           "Check for updates",IDS_UPDATE_FREQUENCY_TXT,51,158,80,10
     COMBOBOX        IDC_UPDATE_FREQUENCY,133,158,66,12,CBS_DROPDOWNLIST | WS_VSCROLL | WS_TABSTOP
@@ -428,7 +428,7 @@ BEGIN
             VALUE "FileDescription", "Rufus"
             VALUE "FileVersion", "4.8.2253"
             VALUE "InternalName", "Rufus"
-            VALUE "LegalCopyright", "© 2011-2025 Pete Batard (GPL v3)"
+            VALUE "LegalCopyright", "Â© 2011-2025 Pete Batard (GPL v3)"
             VALUE "LegalTrademarks", "https://www.gnu.org/licenses/gpl-3.0.html"
             VALUE "OriginalFilename", "rufus-4.8.exe"
             VALUE "ProductName", "Rufus"

--- a/src/stdlg.c
+++ b/src/stdlg.c
@@ -44,6 +44,8 @@
 #include "settings.h"
 #include "license.h"
 
+#include "darkmode.h"
+
 /* Globals */
 extern BOOL is_x86_64, appstore_version;
 extern char unattend_username[MAX_USERNAME_LENGTH], *sbat_level_txt, *sb_active_txt, *sb_revoked_txt;
@@ -329,6 +331,7 @@ INT_PTR CALLBACK LicenseCallback(HWND hDlg, UINT message, WPARAM wParam, LPARAM 
 	HWND hLicense;
 	switch (message) {
 	case WM_INITDIALOG:
+		SetDarkModeForDlg(hDlg);
 		hLicense = GetDlgItem(hDlg, IDC_LICENSE_TEXT);
 		apply_localization(IDD_LICENSE, hDlg);
 		CenterDialog(hDlg, NULL);
@@ -341,6 +344,7 @@ INT_PTR CALLBACK LicenseCallback(HWND hDlg, UINT message, WPARAM wParam, LPARAM 
 		style &= ~(ES_RIGHT);
 		SetWindowLongPtr(hLicense, GWL_STYLE, style);
 		SetDlgItemTextA(hDlg, IDC_LICENSE_TEXT, gplv3);
+		SetDarkModeForChild(hDlg);
 		break;
 	case WM_COMMAND:
 		switch (LOWORD(wParam)) {
@@ -373,6 +377,7 @@ INT_PTR CALLBACK AboutCallback(HWND hDlg, UINT message, WPARAM wParam, LPARAM lP
 
 	switch (message) {
 	case WM_INITDIALOG:
+		SetDarkModeForDlg(hDlg);
 		resized_already = FALSE;
 		// Execute dialog localization
 		apply_localization(IDD_ABOUTBOX, hDlg);
@@ -407,6 +412,7 @@ INT_PTR CALLBACK AboutCallback(HWND hDlg, UINT message, WPARAM wParam, LPARAM lP
 		// Need to send an explicit SetSel to avoid being positioned at the end of richedit control when tabstop is used
 		SendMessage(hEdit[1], EM_SETSEL, 0, 0);
 		SendMessage(hEdit[0], EM_REQUESTRESIZE, 0, 0);
+		SetDarkModeForChild(hDlg);
 		break;
 	case WM_NOTIFY:
 		switch (((LPNMHDR)lParam)->code) {
@@ -479,6 +485,7 @@ INT_PTR CALLBACK NotificationCallback(HWND hDlg, UINT message, WPARAM wParam, LP
 
 	switch (message) {
 	case WM_INITDIALOG:
+		SetDarkModeForDlg(hDlg);
 		// Get the system message box font. See http://stackoverflow.com/a/6057761
 		ncm.cbSize = sizeof(ncm);
 		// If we're compiling with the Vista SDK or later, the NONCLIENTMETRICS struct
@@ -561,6 +568,7 @@ INT_PTR CALLBACK NotificationCallback(HWND hDlg, UINT message, WPARAM wParam, LP
 			ResizeMoveCtrl(hDlg, GetDlgItem(hDlg, IDYES), 0, dh -cbh, 0, 0, 1.0f);
 			ResizeMoveCtrl(hDlg, GetDlgItem(hDlg, IDNO), 0, dh -cbh, 0, 0, 1.0f);
 		}
+		SetDarkModeForChild(hDlg);
 		return (INT_PTR)TRUE;
 	case WM_CTLCOLORSTATIC:
 		// Change the background colour for static text and icon
@@ -690,6 +698,7 @@ static INT_PTR CALLBACK CustomSelectionCallback(HWND hDlg, UINT message, WPARAM 
 
 	switch (message) {
 	case WM_INITDIALOG:
+		SetDarkModeForDlg(hDlg);
 		// Don't overflow our max radio button
 		if (nDialogItems > (IDC_SELECTION_CHOICEMAX - IDC_SELECTION_CHOICE1 + 1)) {
 			uprintf("Warning: Too many options requested for Selection (%d vs %d)",
@@ -796,6 +805,7 @@ static INT_PTR CALLBACK CustomSelectionCallback(HWND hDlg, UINT message, WPARAM 
 		// Set the default selection
 		for (i = 0, m = 1; i < nDialogItems; i++, m <<= 1)
 			Button_SetCheck(GetDlgItem(hDlg, IDC_SELECTION_CHOICE1 + i), (m & selection_dialog_mask) ? BST_CHECKED : BST_UNCHECKED);
+		SetDarkModeForChild(hDlg);
 		return (INT_PTR)TRUE;
 	case WM_CTLCOLORSTATIC:
 		// Change the background colour for static text and icon
@@ -883,6 +893,7 @@ INT_PTR CALLBACK ListCallback(HWND hDlg, UINT message, WPARAM wParam, LPARAM lPa
 
 	switch (message) {
 	case WM_INITDIALOG:
+		SetDarkModeForDlg(hDlg);
 		// Don't overflow our max radio button
 		if (nDialogItems > (IDC_LIST_ITEMMAX - IDC_LIST_ITEM1 + 1)) {
 			uprintf("Warning: Too many items requested for List (%d vs %d)",
@@ -942,6 +953,7 @@ INT_PTR CALLBACK ListCallback(HWND hDlg, UINT message, WPARAM wParam, LPARAM lPa
 		ResizeButtonHeight(hDlg, IDOK);
 		ResizeButtonHeight(hDlg, IDCANCEL);
 		return (INT_PTR)TRUE;
+		SetDarkModeForChild(hDlg);
 	case WM_CTLCOLORSTATIC:
 		// Change the background colour for static text and icon
 		SetBkMode((HDC)wParam, TRANSPARENT);
@@ -1063,6 +1075,7 @@ BOOL CreateTooltip(HWND hControl, const char* message, int duration)
 	if (ttlist[i].hTip == NULL) {
 		return FALSE;
 	}
+	SetDarkTheme(ttlist[i].hTip);
 	ttlist[i].hCtrl = hControl;
 
 	// Subclass the tooltip to handle multiline
@@ -1291,6 +1304,7 @@ INT_PTR CALLBACK UpdateCallback(HWND hDlg, UINT message, WPARAM wParam, LPARAM l
 
 	switch (message) {
 	case WM_INITDIALOG:
+		SetDarkModeForDlg(hDlg);
 		resized_already = FALSE;
 		hUpdatesDlg = hDlg;
 		apply_localization(IDD_UPDATE_POLICY, hDlg);
@@ -1338,6 +1352,7 @@ INT_PTR CALLBACK UpdateCallback(HWND hDlg, UINT message, WPARAM wParam, LPARAM l
 		SendMessage(hPolicy, EM_SETEVENTMASK, 0, ENM_LINK|ENM_REQUESTRESIZE);
 		SendMessageA(hPolicy, EM_SETBKGNDCOLOR, 0, (LPARAM)GetSysColor(COLOR_BTNFACE));
 		SendMessage(hPolicy, EM_REQUESTRESIZE, 0, 0);
+		SetDarkModeForChild(hDlg);
 		break;
 	case WM_NOTIFY:
 		if ((((LPNMHDR)lParam)->code == EN_REQUESTRESIZE) && (!resized_already)) {
@@ -1561,6 +1576,43 @@ void CreateStaticFont(HDC hDC, HFONT* hFont, BOOL underlined)
 	*hFont = CreateFontIndirect(&lf);
 }
 
+void SetHyperLinkFont(HWND hWnd, HDC hDC, HFONT* hFont, BOOL underlined)
+{
+	LOGFONT lf;
+	static BOOL useStaticFont = FALSE;
+	HFONT hFontTmp = NULL;
+
+	if (*hFont == NULL) {
+		ZeroMemory(&lf, sizeof(LOGFONT));
+		hFontTmp = (HFONT)SendMessage(hWnd, WM_GETFONT, 0, 0);
+
+		if (hFontTmp) {
+			GetObject(hFontTmp, sizeof(LOGFONT), &lf);
+			useStaticFont = FALSE;
+		}
+		else {
+			NONCLIENTMETRICS ncm;
+			ZeroMemory(&ncm, sizeof(NONCLIENTMETRICS));
+			ncm.cbSize = sizeof(NONCLIENTMETRICS);
+			if (SystemParametersInfo(SPI_GETNONCLIENTMETRICS, sizeof(NONCLIENTMETRICS), &ncm, 0) == TRUE) {
+				lf = ncm.lfStatusFont;
+				useStaticFont = FALSE;
+			}
+			else {
+				CreateStaticFont(hDC, hFont, underlined);
+				useStaticFont = TRUE;
+			}
+		}
+
+		if (!useStaticFont) {
+			lf.lfUnderline = underlined;
+			*hFont = CreateFontIndirect(&lf);
+		}
+	}
+	if (!useStaticFont)
+		SendMessage(hWnd, WM_SETFONT, (WPARAM)*hFont, TRUE);
+}
+
 /*
  * Work around the limitations of edit control, to display a hand cursor for hyperlinks
  * NB: The LTEXT control must have SS_NOTIFY attribute for this to work
@@ -1587,7 +1639,7 @@ INT_PTR CALLBACK NewVersionCallback(HWND hDlg, UINT message, WPARAM wParam, LPAR
 	char cmdline[] = APPLICATION_NAME " -w 150";
 	static char* filepath = NULL;
 	static int download_status = 0;
-	static HFONT hyperlink_font = NULL;
+	static HFONT hHyperlinkFont = NULL;
 	static HANDLE hThread = NULL;
 	HWND hNotes;
 	LONG err;
@@ -1598,6 +1650,7 @@ INT_PTR CALLBACK NewVersionCallback(HWND hDlg, UINT message, WPARAM wParam, LPAR
 
 	switch (message) {
 	case WM_INITDIALOG:
+		SetDarkModeForDlg(hDlg);
 		apply_localization(IDD_NEW_VERSION, hDlg);
 		download_status = 0;
 		SetTitleBarIcon(hDlg);
@@ -1618,18 +1671,20 @@ INT_PTR CALLBACK NewVersionCallback(HWND hDlg, UINT message, WPARAM wParam, LPAR
 		if (update.download_url == NULL)
 			EnableWindow(GetDlgItem(hDlg, IDC_DOWNLOAD), FALSE);
 		ResizeButtonHeight(hDlg, IDCANCEL);
+		SetDarkModeForChild(hDlg);
+		SubclassProgressBarControl(GetDlgItem(hDlg, IDC_PROGRESS));
+		SetHyperLinkFont(GetDlgItem(hDlg, IDC_WEBSITE), (HDC)wParam, &hHyperlinkFont, TRUE);
 		break;
 	case WM_CTLCOLORSTATIC:
 		if ((HWND)lParam != GetDlgItem(hDlg, IDC_WEBSITE))
 			return FALSE;
 		// Change the font for the hyperlink
 		SetBkMode((HDC)wParam, TRANSPARENT);
-		CreateStaticFont((HDC)wParam, &hyperlink_font, TRUE);
-		SelectObject((HDC)wParam, hyperlink_font);
-		SetTextColor((HDC)wParam, RGB(0,0,125));	// DARK_BLUE
+		SelectObject((HDC)wParam, hHyperlinkFont);
+		SetTextColor((HDC)wParam, GetSysColor(COLOR_HOTLIGHT));
 		return (INT_PTR)GetSysColorBrush(COLOR_BTNFACE);
 	case WM_NCDESTROY:
-		safe_delete_object(hyperlink_font);
+		safe_delete_object(hHyperlinkFont);
 		break;
 	case WM_COMMAND:
 		switch (LOWORD(wParam)) {

--- a/src/ui.c
+++ b/src/ui.c
@@ -969,7 +969,7 @@ static INT_PTR CALLBACK ProgressCallback(HWND hCtrl, UINT message, WPARAM wParam
 		COLORREF cInvText = PROGRESS_BAR_INVERTED_TEXT_COLOR;
 		COLORREF cBorder = PROGRESS_BAR_BOX_COLOR;
 		if (IsDarkModeEnabled()) {
-			cBg = GetControlBackgroundColor();
+			cBg = GetCtrlBackgroundColor();
 			cText = PROGRESS_BAR_INVERTED_TEXT_COLOR;
 			cInvText = PROGRESS_BAR_NORMAL_TEXT_COLOR;
 			cBorder = GetEdgeColor();


### PR DESCRIPTION
<!--
Please do not create an unsolicited Pull Requests for a translation update.
See https://github.com/pbatard/rufus/wiki/FAQ#user-content-Why_dont_you_accept_unsolicited_translation_updates.
-->
fix #1453

My attempt of dark mode for rufus. I was working on this before I've noticed PR #2510 and since it is working quite good I've decided to share it. 
It was quite fun to remember difference between c++ and c, when I was porting some code.

This implementation has some considerations which I will not fix, such as "?" static text, green "?" in picture below, on rufus launch when in disabled state it may not look good. 
There is no automatic change when user changes system dark mode. The change is not perfect for classic win32 apps, and may cause issues until app is restarted. I consider it important to not cause issues for rufus when it is doing its job such as creating bootable flash drives.
Dark mode is not implemented for system message boxes, as they are part of OS and not rufus.
It is also not implemented for "download"  scripts windows.

And mainly it will work only on latest Windows 10 build 19045 and Windows 11.

![image](https://github.com/user-attachments/assets/4e09f7dc-9d9c-42c8-b60b-f898ed714ce9)
![image](https://github.com/user-attachments/assets/97e0969c-887e-485f-b145-a7de3c810e89)
![image](https://github.com/user-attachments/assets/1b4a3575-384b-4146-8f19-2ee12a2ce501)
![image](https://github.com/user-attachments/assets/fe3fe2e0-77ef-4a25-82e4-433ad08a83cf)
![image](https://github.com/user-attachments/assets/f405af8b-58cb-4b2a-82c0-46cc24e28ddd)


