### PR TITLE
Fix broken dark mode on old Windows 10 builds

### DIFF
--- a/src/darkmode.h
+++ b/src/darkmode.h
@@ -25,6 +25,8 @@
 extern BOOL is_darkmode_enabled;
 
 typedef enum _WindowsBuild {
+	WIN10_1809 = 17763, // first build to support dark mode
+	WIN10_1903 = 18362,
 	WIN10_22H2 = 19045,
 	WIN11_21H2 = 22000,
 } WindowsBuild;


### PR DESCRIPTION
<!--
Please do not create an unsolicited Pull Requests for a translation update.
See https://github.com/pbatard/rufus/wiki/FAQ#user-content-Why_dont_you_accept_unsolicited_translation_updates.
-->
fix #2766