### PR TITLE
Assertion Failure Issue Assert update_boot_wim

### DIFF
--- a/src/wue.c
+++ b/src/wue.c
@@ -1000,7 +1000,7 @@ BOOL ApplyWindowsCustomization(char drive_letter, int flags)
 	}
 
 	if (flags & UNATTEND_USE_MS2023_BOOTLOADERS) {
-		if_assert_fails(update_boot_wim)
+		if_assert_fails(!update_boot_wim)
 			goto out;
 		if (GetTempDirNameU(temp_dir, APPLICATION_NAME, 0, tmp_path[1]) == 0) {
 			uprintf("WARNING: Could not create temp dir for 2023 signed UEFI bootloaders");


### PR DESCRIPTION
Assertion Failure issue - Assert update_boot_wim

When, Windows User Experience->Customize Windows installation?-> Check box "Use 'Windows CA 2023' signed bootloaders" is checked.

<!--
Please do not create an unsolicited Pull Requests for a translation update.
See https://github.com/pbatard/rufus/wiki/FAQ#user-content-Why_dont_you_accept_unsolicited_translation_updates.
-->