### PR TITLE
[efi] make the UEFI:NTFS partition hidden

### DIFF
--- a/src/drive.c
+++ b/src/drive.c
@@ -2456,8 +2456,10 @@ BOOL CreatePartition(HANDLE hDrive, int partition_style, int file_system, BOOL m
 				// lest the Microsoft Windows installer errors out at "Copying Windows Files"
 				// because it just can't handle 2 ESPs on one system. The horror! The horror!
 				DriveLayoutEx.PartitionEntry[i].Gpt.PartitionType = PARTITION_MICROSOFT_DATA;
-				// Prevent a drive letter from being assigned to the UEFI:NTFS partition
-				DriveLayoutEx.PartitionEntry[i].Gpt.Attributes = GPT_BASIC_DATA_ATTRIBUTE_NO_DRIVE_LETTER;
+				// When declaring an EFI system partition type, "no drive letter" attribute works as expected.
+				// Now that we declare it as a Microsoft Basic Data partition, that attribute does not work consistently (i.e. drive letter is ALWAYS assigned).
+				// Set the "hidden" attribute, which will ALWAYS prevent a drive letter from being assigned to the UEFI:NTFS partition
+				DriveLayoutEx.PartitionEntry[i].Gpt.Attributes = GPT_BASIC_DATA_ATTRIBUTE_HIDDEN;
 #if !defined(_DEBUG)
 				// Also make the partition read-only for release versions
 				DriveLayoutEx.PartitionEntry[i].Gpt.Attributes += GPT_BASIC_DATA_ATTRIBUTE_READ_ONLY;


### PR DESCRIPTION
ESP, MSR and Windows Recovery partition types all have the attribute bit 63 (no drive letter) set when installing Windows.
So those partitions never get a drive letter in Windows, as expected.

On the other hand, Microsoft Basic Data partition type most of the time get a drive letter in Windows, despite having bit 63 (no drive letter) assigned. This attribute is getting ignored.
I noticed this strange behavior in these situations:
- During the USB drive creation (when Rufus create the 2 partitions in the GPT + NTFS configuration)
- When the USB drive is moved to another PC/VM
- Sometimes, when the USB drive is unplugged/replugged to the same machine

This behavior probably happens because "Only partitions of this type can be [...] enumerated by calls to FindFirstVolume and FindNextVolume." See https://learn.microsoft.com/en-us/windows/win32/api/vds/ns-vds-create_partition_parameters#members and https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dmrp/5f5043a3-9e6d-40cc-a05b-1a4a3617df32#Appendix_A_23

For UEFI_NTFS we are not using the standard ESP type, because of this Microsoft bug [59fd550](https://github.com/pbatard/rufus/commit/59fd550c468f13ab086076061f26f9ce15a93d51), although this is really an ESP!

Since the end user does not have to deal with this tiny partition and 'hiding' it from the OS won't affect UEFI boot capability, let's change the attribute from "no drive letter" (bit 63) to "hidden" (bit 62)

<br/><br/>

Here is the Rufus log of my PR change 
[rufus.log](https://github.com/user-attachments/files/23013922/rufus.log)

And here 2 videos of Rufus in action, actual behavior and new behavior


https://github.com/user-attachments/assets/8a1815ad-f5e3-4e05-899c-ddb3029a17d8


https://github.com/user-attachments/assets/7913e887-b503-4edd-a49f-783b7392af35



<!--
Please do not create an unsolicited Pull Requests for a translation update.
See https://github.com/pbatard/rufus/wiki/FAQ#user-content-Why_dont_you_accept_unsolicited_translation_updates.
-->