### PR TITLE
src/rufus: Prevent assertion failure if START is clicked while image_path is NULL

### DIFF
--- a/src/rufus.c
+++ b/src/rufus.c
@@ -2626,11 +2626,6 @@ static INT_PTR CALLBACK MainCallback(HWND hDlg, UINT message, WPARAM wParam, LPA
 				return (INT_PTR)TRUE;
 			// Just in case
 			boot_type = (int)ComboBox_GetCurItemData(hBootType);
-			// Prevent asserting if hStart somehow became enabled without an image
-			if ((boot_type == BT_IMAGE) && (image_path == NULL)) {
-				EnableControls(TRUE, FALSE);
-				return (INT_PTR)TRUE;
-			}
 			partition_type = (int)ComboBox_GetCurItemData(hPartitionScheme);
 			target_type = (int)ComboBox_GetCurItemData(hTargetSystem);
 			fs_type = (int)ComboBox_GetCurItemData(hFileSystem);


### PR DESCRIPTION
This commit adds a defensive check to ensure that clicking the START button when no image has been selected (e.g. if the UI accidentally enables it or is in an inconsistent state) does not trigger an assertion failure. Closes #2923.