### PR TITLE
fix: arithmetic multiplication used to compute alloc... in...

### DIFF
--- a/src/badblocks.c
+++ b/src/badblocks.c
@@ -67,7 +67,7 @@ static errcode_t make_u64_list(int size, int num, uint64_t *list, bb_u64_list *r
 	bb->magic = BB_ET_MAGIC_BADBLOCKS_LIST;
 	bb->size = size ? size : 10;
 	bb->num = num;
-	bb->list = malloc(sizeof(blk64_t) * bb->size);
+	bb->list = calloc(bb->size, sizeof(blk64_t));
 	if (bb->list == NULL) {
 		free(bb);
 		bb = NULL;


### PR DESCRIPTION
## Summary
Fix high severity security issue in `src/badblocks.c`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | utils.custom.integer-overflow-malloc |
| **Severity** | HIGH |
| **Scanner** | semgrep |
| **Rule** | `utils.custom.integer-overflow-malloc` |
| **File** | `src/badblocks.c:70` |

**Description**: Arithmetic multiplication used to compute allocation size without overflow check. If the multiplication wraps, a too-small buffer is allocated, leading to heap overflow. Check for overflow before allocating.


## Changes
- `src/badblocks.c`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
