### PR TITLE
[xml] Fix unrestricted entity expansion and integer overflow in ezxml parser

### DIFF
--- a/src/xml.c
+++ b/src/xml.c
@@ -67,8 +67,12 @@ struct ezxml_root {       // additional data for the root tag
 
 char *EZXML_NIL[] = { NULL }; // empty, null terminated array of strings
 
+// Maximum total bytes of entity-expanded text before we bail out.
+// Prevents exponential blowup from nested entity definitions (billion laughs).
+#define EZXML_MAX_ENTITY_EXPANSION  (8 * 1024 * 1024)  // 8 MB
+
 // what realloc should be doing all along
-static inline void* _realloc(void* ptr, unsigned int size) {
+static inline void* _realloc(void* ptr, size_t size) {
     void* old_ptr = ptr;
     ptr = realloc(ptr, size);
     if (ptr == NULL)
@@ -200,7 +204,9 @@ ezxml_t ezxml_err(ezxml_root_t root, char *s, const char *err, ...)
 char *ezxml_decode(char *s, char **ent, char t)
 {
     char *e, *r = s, *m = s;
-    long b, c, d, l;
+    long b, c, d;
+    size_t l;
+    size_t total_expanded = 0; // track total entity expansion to prevent XML bombs
 
     for (; *s; s++) { // normalize line endings
         while (*s == '\r') {
@@ -236,10 +242,19 @@ char *ezxml_decode(char *s, char **ent, char t)
                  b += 2); // find entity in entity list
 
             if (ent[b++]) { // found a match
-                if ((c = (long)strlen(ent[b])) - 1 > (e = strchr(s, ';')) - s) {
-                    l = (d = (long)(s - r)) + c + (long)(e ? strlen(e) : 0); // new length
+                c = (long)strlen(ent[b]);
+                total_expanded += (size_t)c;
+                if (total_expanded > EZXML_MAX_ENTITY_EXPANSION) {
+                    // Entity expansion limit exceeded - abort to prevent
+                    // exponential blowup (billion laughs / XML bomb).
+                    break;
+                }
+
+                if (c - 1 > (e = strchr(s, ';')) - s) {
+                    size_t d_off = (size_t)(s - r);
+                    l = d_off + (size_t)c + (e ? strlen(e) : 0); // new length
                     r = (r == m) ? strcpy(malloc(l), r) : _realloc(r, l);
-                    e = strchr((s = r + d), ';'); // fix up pointers
+                    e = strchr((s = r + d_off), ';'); // fix up pointers
                 }
                 if (!e) return r;
 
@@ -254,7 +269,7 @@ char *ezxml_decode(char *s, char **ent, char t)
 
     if (t == '*') { // normalize spaces for non-cdata attributes
         for (s = r; *s; s++) {
-            if ((l = (long)strspn(s, " "))) memmove(s, s + l, strlen(s + l) + 1);
+            if ((l = (size_t)strspn(s, " "))) memmove(s, s + l, strlen(s + l) + 1);
             while (*s && *s != ' ') s++;
         }
         if (--s >= r && *s == ' ') *s = '\0'; // trim any trailing space


### PR DESCRIPTION
## Vulnerability class

Denial of service via XML entity expansion (billion laughs attack), with secondary integer overflow leading to heap buffer overflow.

**Severity**: High (DoS), with potential for memory corruption on sustained expansion.

## Affected file and line range

`src/xml.c` - `ezxml_decode()` (line 204), `_realloc()` (line 74)

## Description

The bundled ezxml parser does not limit how much text entity expansion can produce. The `ezxml_decode()` function processes entity references by substituting their values into the working string, then continues scanning forward through the substituted text. If the substituted text contains further entity references, those are expanded in turn. This is recursive expansion driven by a forward scan - not a depth-limited stack.

An XML document with nested entity definitions exploits this:

```xml
<!DOCTYPE bomb [
  <!ENTITY x0 "BOOM">
  <!ENTITY x1 "&x0;&x0;">
  <!ENTITY x2 "&x1;&x1;">
  ...
  <!ENTITY x30 "&x29;&x29;">
]>
<bomb>&x30;</bomb>
```

Each level doubles the output. With 30 levels, a ~700-byte input expands to 4 GB of text. The existing `ezxml_ent_ok()` function only rejects direct circular references (A references B references A). It does not detect or limit exponential expansion through fan-out.

This is reachable in Rufus through crafted WIM XML metadata inside a malicious ISO file. The code path is `wue.c` -> `ezxml_parse_str()` -> `ezxml_internal_dtd()` + `ezxml_decode()`.

Two secondary issues in the same code path compound the problem:

1. **`_realloc()` takes `unsigned int` instead of `size_t`** - On 64-bit builds, callers pass `size_t` values that get silently truncated to 32 bits. If the true allocation size exceeds `UINT_MAX`, the truncated value causes a too-small allocation, and subsequent writes overflow the heap buffer.

2. **`ezxml_decode()` uses `long` for size calculations** - On Windows, `long` is 32 bits on both x86 and x64. When the entity-expanded string approaches 2 GB, the arithmetic at line 244 (`l = (d = (long)(s - r)) + c + (long)(e ? strlen(e) : 0)`) overflows. A positive-but-too-small result causes `malloc`/`_realloc` to succeed with an undersized buffer, and the following `strcpy`/`memmove` writes past the end.

## Proof of concept

Generate the XML bomb (works on any system with a C compiler):

```c
#include <stdio.h>
#include <stdlib.h>
#include <string.h>

static char *build_xml_bomb(int depth) {
    char line[128];
    size_t alloc = 4096, len = 0;
    char *xml = malloc(alloc);
    if (!xml) return NULL;
    len += snprintf(xml + len, alloc - len, "<!DOCTYPE bomb [\n");
    len += snprintf(xml + len, alloc - len, "  <!ENTITY x0 \"BOOM\">\n");
    for (int i = 1; i <= depth; i++) {
        snprintf(line, sizeof(line),
                 "  <!ENTITY x%d \"&x%d;&x%d;\">\n", i, i - 1, i - 1);
        while (len + strlen(line) + 1 > alloc) {
            alloc *= 2;
            xml = realloc(xml, alloc);
            if (!xml) return NULL;
        }
        len += snprintf(xml + len, alloc - len, "%s", line);
    }
    snprintf(line, sizeof(line), "]>\n<bomb>&x%d;</bomb>\n", depth);
    while (len + strlen(line) + 1 > alloc) {
        alloc *= 2;
        xml = realloc(xml, alloc);
        if (!xml) return NULL;
    }
    len += snprintf(xml + len, alloc - len, "%s", line);
    return xml;
}

int main(void) {
    char *xml = build_xml_bomb(25);
    if (xml) { printf("%s", xml); free(xml); }
    return 0;
}
```

Compile and pipe into a WIM XML metadata field, or pass directly to `ezxml_parse_str()`. With depth=25, the expected expansion is 128 MB. With depth=30, it is 4 GB.

Amplification at depth 20: a 612-byte input produces 4 MB of expanded text (6,853x amplification).

In a real attack scenario, this XML would be embedded in a WIM file's XML metadata block inside a crafted ISO image. When the user opens the ISO in Rufus to create a bootable USB, the WIM parsing code calls `ezxml_parse_str()`, triggering the expansion.

## Patch explanation

Three changes, all in `src/xml.c`:

1. **Add `EZXML_MAX_ENTITY_EXPANSION` (8 MB)** - `ezxml_decode()` now tracks cumulative bytes of entity replacement text. When the total exceeds 8 MB, expansion stops. This directly prevents the exponential blowup. 8 MB is far above what any legitimate Windows installer XML needs, but stops the bomb before it can consume significant memory.

2. **Change `_realloc()` parameter from `unsigned int` to `size_t`** - Matches the type that callers actually pass. Prevents silent truncation of allocation sizes on 64-bit builds.

3. **Change size variable `l` from `long` to `size_t`; use local `size_t d_off` for offset** - Prevents signed integer overflow in the buffer size calculation. On Windows, `long` is always 32 bits. Using `size_t` matches pointer arithmetic width on both x86 and x64.