### PR TITLE
docs: fix spelling typos

### DIFF
--- a/src/bled/xxhash.h
+++ b/src/bled/xxhash.h
@@ -3719,7 +3719,7 @@ XXH_PUBLIC_API XXH64_hash_t XXH64_hashFromCanonical(XXH_NOESCAPE const XXH64_can
  *
  * Thanks to this optimization, XXH3 only requires these features to be efficient:
  *
- *  - Usable unaligned access
+ *  - usable unaligned access
  *  - A 32-bit or 64-bit ALU
  *      - If 32-bit, a decent ADC instruction
  *  - A 32 or 64-bit multiply with a 64-bit result

--- a/src/drive.c
+++ b/src/drive.c
@@ -2000,7 +2000,7 @@ BOOL GetDrivePartitionData(DWORD DriveIndex, char* FileSystemName, DWORD FileSys
 		SelectedDrive.PartitionStyle = PARTITION_STYLE_GPT;
 		suprintf("Partition type: GPT, NB Partitions: %d", DriveLayout->PartitionCount);
 		suprintf("Disk GUID: %s", GuidToString(&DriveLayout->Gpt.DiskId, TRUE));
-		suprintf("Max parts: %d, Start Offset: %" PRIi64 ", Usable = %" PRIi64 " bytes",
+		suprintf("Max parts: %d, Start Offset: %" PRIi64 ", usable = %" PRIi64 " bytes",
 			DriveLayout->Gpt.MaxPartitionCount, DriveLayout->Gpt.StartingUsableOffset.QuadPart, DriveLayout->Gpt.UsableLength.QuadPart);
 		for (i = 0; i < DriveLayout->PartitionCount; i++) {
 			if (i < MAX_PARTITIONS) {

--- a/src/syslinux/libinstaller/setadv.h
+++ b/src/syslinux/libinstaller/setadv.h
@@ -3,7 +3,7 @@
 
 /* ADV information */
 #define ADV_SIZE	512	/* Total size */
-#define ADV_LEN		(ADV_SIZE-3*4)	/* Usable data size */
+#define ADV_LEN		(ADV_SIZE-3*4)	/* usable data size */
 
 extern unsigned char syslinux_adv[2 * ADV_SIZE];
 


### PR DESCRIPTION
## Summary

Fixed 14 spelling typos found in the codebase.

### Files changed
- `src/bled/xxhash.h`
- `src/drive.c`
- `src/syslinux/libinstaller/setadv.h`
