### PR TITLE
Add opt-in Mica backdrop support on Windows 11 22H2+

### DIFF
--- a/src/darkmode.c
+++ b/src/darkmode.c
@@ -209,9 +209,15 @@ void SetMicaBackdrop(HWND hWnd)
 	enum DWM_SYSTEMBACKDROP_TYPE backdrop = DWMSBT_MAINWINDOW;
 	MARGINS margins = { -1, -1, -1, -1 };
 
-	if (!IsAtLeastWin11_22H2())
+	if (!IsAtLeastWin11_22H2() || ReadSetting32(SETTING_MICA) != 1)
 		return;
 	DwmSetWindowAttribute(hWnd, DWMWA_SYSTEMBACKDROP_TYPE, &backdrop, sizeof(backdrop));
+	// Light-mode GDI text is naturally dark; ClearType edges drift toward
+	// pure black which DWM's chroma-key then erases, making labels vanish.
+	// Skip the client-area extension in light mode so only the title bar
+	// gets Mica - matching how most first-party Win11 apps behave.
+	if (!is_darkmode_enabled)
+		return;
 	DwmExtendFrameIntoClientArea(hWnd, &margins);
 	if (!GetWindowSubclass(hWnd, MicaBackgroundSubclass, (UINT_PTR)MicaBackgroundSubclassID, NULL))
 		SetWindowSubclass(hWnd, MicaBackgroundSubclass, (UINT_PTR)MicaBackgroundSubclassID, 0);

--- a/src/darkmode.c
+++ b/src/darkmode.c
@@ -149,17 +149,60 @@ void SetDarkTheme(HWND hWnd)
 	SetWindowTheme(hWnd, is_darkmode_enabled ? L"DarkMode_Explorer" : NULL, NULL);
 }
 
-// Mica system backdrop (Win11 22H2+). DWM blends desktop wallpaper through the
-// non-client area; the client area only shows Mica where the window does not
-// paint over it, so Rufus's solid dark/light brushes will limit the effect to
-// the title bar. Safe to call on any Windows version.
+// Extend Mica into the client area via DWM frame extension + chroma-key.
+// Within the extended frame, pure black (RGB 0,0,0) is composed as transparent
+// so DWM's Mica backdrop shows through. We fill every dialog/static background
+// with BLACK_BRUSH and draw text in TRANSPARENT mode so only glyph pixels
+// remain opaque over the Mica.
+static LRESULT CALLBACK MicaBackgroundSubclass(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam,
+	UINT_PTR uIdSubclass, DWORD_PTR dwRefData)
+{
+	HDC hdc;
+	RECT rc;
+	(void)dwRefData;
+
+	switch (uMsg) {
+	case WM_NCDESTROY:
+		RemoveWindowSubclass(hWnd, MicaBackgroundSubclass, uIdSubclass);
+		break;
+
+	case WM_ERASEBKGND:
+		hdc = (HDC)wParam;
+		GetClientRect(hWnd, &rc);
+		FillRect(hdc, &rc, (HBRUSH)GetStockObject(BLACK_BRUSH));
+		return TRUE;
+
+	case WM_CTLCOLORDLG:
+		return (LRESULT)GetStockObject(BLACK_BRUSH);
+
+	case WM_CTLCOLORSTATIC:
+		hdc = (HDC)wParam;
+		SetBkMode(hdc, TRANSPARENT);
+		// Light-mode text uses RGB(1,1,1) instead of pure black to avoid being
+		// chroma-keyed transparent by DWM along with the background
+		SetTextColor(hdc, is_darkmode_enabled ? DARKMODE_NORMAL_TEXT_COLOR : RGB(1, 1, 1));
+		return (LRESULT)GetStockObject(BLACK_BRUSH);
+	}
+	return DefSubclassProc(hWnd, uMsg, wParam, lParam);
+}
+
+// Mica system backdrop (Win11 22H2+). Combines DWMSBT_MAINWINDOW (Mica behind
+// the non-client area) with DwmExtendFrameIntoClientArea (-1 margins) so the
+// entire window participates in DWM's chroma-key compositing. The subclass
+// then paints black where Mica should show. Safe to call on any Windows
+// version - older builds return early before any DWM work.
 void SetMicaBackdrop(HWND hWnd)
 {
 	enum DWM_SYSTEMBACKDROP_TYPE backdrop = DWMSBT_MAINWINDOW;
+	MARGINS margins = { -1, -1, -1, -1 };
 
 	if (!IsAtLeastWin11_22H2())
 		return;
 	DwmSetWindowAttribute(hWnd, DWMWA_SYSTEMBACKDROP_TYPE, &backdrop, sizeof(backdrop));
+	DwmExtendFrameIntoClientArea(hWnd, &margins);
+	if (!GetWindowSubclass(hWnd, MicaBackgroundSubclass, (UINT_PTR)MicaBackgroundSubclassID, NULL))
+		SetWindowSubclass(hWnd, MicaBackgroundSubclass, (UINT_PTR)MicaBackgroundSubclassID, 0);
+	InvalidateRect(hWnd, NULL, TRUE);
 }
 
 /*

--- a/src/darkmode.c
+++ b/src/darkmode.c
@@ -169,8 +169,20 @@ static LRESULT CALLBACK MicaBackgroundSubclass(HWND hWnd, UINT uMsg, WPARAM wPar
 
 	case WM_ERASEBKGND:
 		hdc = (HDC)wParam;
-		GetClientRect(hWnd, &rc);
-		FillRect(hdc, &rc, (HBRUSH)GetStockObject(BLACK_BRUSH));
+		GetClipBox(hdc, &rc);
+		// Use buffered paint with alpha=0 so DWM composites the region as
+		// truly transparent in a single atomic blit, instead of relying on
+		// chroma-key scanning of black pixels. Eliminates the visible flash
+		// during window resize.
+		HDC hdcBuffer = NULL;
+		HPAINTBUFFER hpb = BeginBufferedPaint(hdc, &rc, BPBF_TOPDOWNDIB, NULL, &hdcBuffer);
+		if (hpb != NULL && hdcBuffer != NULL) {
+			FillRect(hdcBuffer, &rc, (HBRUSH)GetStockObject(BLACK_BRUSH));
+			BufferedPaintSetAlpha(hpb, NULL, 0);
+			EndBufferedPaint(hpb, TRUE);
+		} else {
+			FillRect(hdc, &rc, (HBRUSH)GetStockObject(BLACK_BRUSH));
+		}
 		return TRUE;
 
 	case WM_CTLCOLORDLG:

--- a/src/darkmode.c
+++ b/src/darkmode.c
@@ -67,6 +67,11 @@ static inline BOOL IsAtLeastWin11(void)
 	return IsAtLeastWin10Build(WIN11_21H2);
 }
 
+static inline BOOL IsAtLeastWin11_22H2(void)
+{
+	return IsAtLeastWin10Build(WIN11_22H2);
+}
+
 static inline BOOL IsHighContrast(void)
 {
 	HIGHCONTRASTW highContrast = { 0 };
@@ -142,6 +147,19 @@ out:
 void SetDarkTheme(HWND hWnd)
 {
 	SetWindowTheme(hWnd, is_darkmode_enabled ? L"DarkMode_Explorer" : NULL, NULL);
+}
+
+// Mica system backdrop (Win11 22H2+). DWM blends desktop wallpaper through the
+// non-client area; the client area only shows Mica where the window does not
+// paint over it, so Rufus's solid dark/light brushes will limit the effect to
+// the title bar. Safe to call on any Windows version.
+void SetMicaBackdrop(HWND hWnd)
+{
+	enum DWM_SYSTEMBACKDROP_TYPE backdrop = DWMSBT_MAINWINDOW;
+
+	if (!IsAtLeastWin11_22H2())
+		return;
+	DwmSetWindowAttribute(hWnd, DWMWA_SYSTEMBACKDROP_TYPE, &backdrop, sizeof(backdrop));
 }
 
 /*

--- a/src/darkmode.c
+++ b/src/darkmode.c
@@ -41,6 +41,7 @@ PF_TYPE_DECL(WINAPI, VOID, FlushMenuThemes, (VOID));
 PF_TYPE_DECL(WINAPI, BOOL, SetWindowCompositionAttribute, (HWND, WINDOWCOMPOSITIONATTRIBDATA*));
 
 BOOL is_darkmode_enabled = FALSE;
+BOOL is_mica_enabled = FALSE;
 
 static COLORREF color_accent = TOOLBAR_ICON_COLOR;
 
@@ -202,6 +203,7 @@ void SetMicaBackdrop(HWND hWnd)
 	DwmExtendFrameIntoClientArea(hWnd, &margins);
 	if (!GetWindowSubclass(hWnd, MicaBackgroundSubclass, (UINT_PTR)MicaBackgroundSubclassID, NULL))
 		SetWindowSubclass(hWnd, MicaBackgroundSubclass, (UINT_PTR)MicaBackgroundSubclassID, 0);
+	is_mica_enabled = TRUE;
 	InvalidateRect(hWnd, NULL, TRUE);
 }
 
@@ -741,7 +743,10 @@ static LRESULT DarkToolBarNotifyCustomDraw(HWND hWnd, UINT uMsg, WPARAM wParam, 
 	case CDDS_PREPAINT:
 		if (IsAtLeastWin11())
 			roundness = 5;
-		FillRect(lpnmtbcd->nmcd.hdc, &lpnmtbcd->nmcd.rc, GetDlgBackgroundBrush());
+		// Use chroma-key black when Mica is active so the toolbar background
+		// participates in DWM's compositor instead of painting solid dark
+		FillRect(lpnmtbcd->nmcd.hdc, &lpnmtbcd->nmcd.rc,
+			is_mica_enabled ? (HBRUSH)GetStockObject(BLACK_BRUSH) : GetDlgBackgroundBrush());
 		return CDRF_NOTIFYITEMDRAW;
 
 	case CDDS_ITEMPREPAINT:

--- a/src/darkmode.h
+++ b/src/darkmode.h
@@ -29,6 +29,7 @@ typedef enum _WindowsBuild {
 	WIN10_1903 = 18362,
 	WIN10_22H2 = 19045,
 	WIN11_21H2 = 22000,
+	WIN11_22H2 = 22621, // first build to support Mica via DWMWA_SYSTEMBACKDROP_TYPE
 } WindowsBuild;
 
 typedef enum _SubclassID {
@@ -121,6 +122,7 @@ typedef struct {
 BOOL GetDarkModeFromRegistry(void);
 void InitDarkMode(HWND hWnd);
 void SetDarkTitleBar(HWND hWnd);
+void SetMicaBackdrop(HWND hWnd);
 void SetDarkTheme(HWND hWnd);
 BOOL InitAccentColor(void);
 BOOL ChangeIconColor(HICON* hIcon, COLORREF newColor);
@@ -137,6 +139,8 @@ static __inline void SetDarkModeForDlg(HWND hWnd)
 		SetDarkTitleBar(hWnd);
 		SubclassCtlColor(hWnd);
 	}
+	// Mica follows the system theme and is independent of the app's dark mode setting
+	SetMicaBackdrop(hWnd);
 }
 
 static __inline void InitAndSetDarkModeForMainDlg(HWND hWnd)
@@ -147,5 +151,7 @@ static __inline void InitAndSetDarkModeForMainDlg(HWND hWnd)
 		InitAccentColor();
 		SetDarkModeForDlg(hWnd);
 		SubclassNotifyCustomDraw(hWnd);
+	} else {
+		SetMicaBackdrop(hWnd);
 	}
 }

--- a/src/darkmode.h
+++ b/src/darkmode.h
@@ -23,6 +23,7 @@
 #include <uxtheme.h>
 
 extern BOOL is_darkmode_enabled;
+extern BOOL is_mica_enabled;
 
 typedef enum _WindowsBuild {
 	WIN10_1809 = 17763, // first build to support dark mode

--- a/src/darkmode.h
+++ b/src/darkmode.h
@@ -39,7 +39,8 @@ typedef enum _SubclassID {
 	StatusBarSubclassID,
 	ProgressBarSubclassID,
 	StaticTextSubclassID,
-	WindowCtlColorSubclassID
+	WindowCtlColorSubclassID,
+	MicaBackgroundSubclassID
 } SubclassID;
 
 typedef enum _PreferredAppMode {

--- a/src/resource.h
+++ b/src/resource.h
@@ -193,6 +193,7 @@
 #define IDC_LIST_ITEM14                 1116
 #define IDC_LIST_ITEM15                 1117
 #define IDC_LIST_ITEMMAX                1118
+#define IDC_ENABLE_MICA                 1119
 #define IDS_DEVICE_TXT                  2000
 #define IDS_PARTITION_TYPE_TXT          2001
 #define IDS_FILE_SYSTEM_TXT             2002

--- a/src/rufus.c
+++ b/src/rufus.c
@@ -4221,6 +4221,17 @@ extern int TestHashes(void);
 				PostMessage(hDlg, WM_COMMAND, IDCANCEL, 0);
 				continue;
 			}
+			// Ctrl-Alt-M => Toggle Mica backdrop and restart (Win11 22H2+ only).
+			// As with dark mode, once enabled, Rufus forces the mode until the
+			// registry key is removed manually.
+			if ((msg.message == WM_KEYDOWN) && (msg.wParam == 'M') &&
+				(GetKeyState(VK_CONTROL) & 0x8000) && (GetKeyState(VK_MENU) & 0x8000)) {
+				WriteSetting32(SETTING_MICA, is_mica_enabled ? 0 : 1);
+				selected_fs = (int)ComboBox_GetCurItemData(hFileSystem);
+				relaunch = TRUE;
+				PostMessage(hDlg, WM_COMMAND, IDCANCEL, 0);
+				continue;
+			}
 			// Ctrl-Alt-E => Expert Mode
 			if ((msg.message == WM_KEYDOWN) && (msg.wParam == 'E') &&
 				(GetKeyState(VK_CONTROL) & 0x8000) && (GetKeyState(VK_MENU) & 0x8000)) {

--- a/src/rufus.rc
+++ b/src/rufus.rc
@@ -207,7 +207,7 @@ BEGIN
     LTEXT           "List 16",IDC_LIST_ITEMMAX,35,172,269,10,SS_PATHELLIPSIS | NOT WS_VISIBLE
 END
 
-IDD_UPDATE_POLICY DIALOGEX 0, 0, 287, 198
+IDD_UPDATE_POLICY DIALOGEX 0, 0, 287, 213
 STYLE DS_SETFONT | DS_MODALFRAME | WS_POPUP | WS_CAPTION | WS_SYSMENU
 CAPTION "Update policy and settings"
 FONT 9, "Segoe UI Symbol", 400, 0, 0x0
@@ -222,6 +222,7 @@ BEGIN
     GROUPBOX        "",IDS_CHECK_NOW_GRP,210,145,71,46
     PUSHBUTTON      "Check Now",IDC_CHECK_NOW,221,158,50,11
     DEFPUSHBUTTON   "Close",IDCANCEL,221,173,50,11,WS_GROUP
+    AUTOCHECKBOX    "Enable Mica backdrop (dark mode only, requires restart)",IDC_ENABLE_MICA,45,196,236,10
 END
 
 IDD_NEW_VERSION DIALOGEX 0, 0, 384, 268
@@ -430,7 +431,7 @@ BEGIN
             VALUE "FileDescription", "Rufus"
             VALUE "FileVersion", "4.15.2382"
             VALUE "InternalName", "Rufus"
-            VALUE "LegalCopyright", "© 2011-2026 Pete Batard (GPL v3)"
+            VALUE "LegalCopyright", "ï¿½ 2011-2026 Pete Batard (GPL v3)"
             VALUE "LegalTrademarks", "https://www.gnu.org/licenses/gpl-3.0.html"
             VALUE "OriginalFilename", "rufus-4.15.exe"
             VALUE "ProductName", "Rufus"

--- a/src/settings.h
+++ b/src/settings.h
@@ -34,6 +34,7 @@ extern char* ini_file;
 #define SETTING_COMM_CHECK                  "CommCheck64"
 #define SETTING_DEFAULT_THREAD_PRIORITY     "DefaultThreadPriority"
 #define SETTING_DARK_MODE                   "DarkMode"
+#define SETTING_MICA                        "Mica"
 #define SETTING_DISABLE_FAKE_DRIVES_CHECK   "DisableFakeDrivesCheck"
 #define SETTING_DISABLE_LGP                 "DisableLGP"
 #define SETTING_DISABLE_RUFUS_MBR           "DisableRufusMBR"

--- a/src/stdlg.c
+++ b/src/stdlg.c
@@ -1610,6 +1610,10 @@ INT_PTR CALLBACK UpdateCallback(HWND hDlg, UINT message, WPARAM wParam, LPARAM l
 		IGNORE_RETVAL(ComboBox_AddStringU(hBeta, lmprintf(MSG_008)));
 		IGNORE_RETVAL(ComboBox_AddStringU(hBeta, lmprintf(MSG_009)));
 		IGNORE_RETVAL(ComboBox_SetCurSel(hBeta, (ReadSettingBool(SETTING_INCLUDE_BETAS) && is_x86_64) ? 0 : 1));
+		// Mica backdrop is only available on Windows 11 22H2+ (build 22621)
+		CheckDlgButton(hDlg, IDC_ENABLE_MICA,
+			(ReadSetting32(SETTING_MICA) == 1) ? BST_CHECKED : BST_UNCHECKED);
+		EnableWindow(GetDlgItem(hDlg, IDC_ENABLE_MICA), WindowsVersion.BuildNumber >= 22621);
 		hPolicy = GetDlgItem(hDlg, IDC_POLICY);
 		SendMessage(hPolicy, EM_AUTOURLDETECT, 1, 0);
 		static_sprintf(update_policy_text, update_policy, lmprintf(MSG_179|MSG_RTF),
@@ -1634,6 +1638,9 @@ INT_PTR CALLBACK UpdateCallback(HWND hDlg, UINT message, WPARAM wParam, LPARAM l
 			ResizeMoveCtrl(hDlg, hPolicy, 0, 0, 0, -dy, 1.0f);
 			for (i = 2; i < ARRAYSIZE(update_settings_reposition_ids); i++)
 				ResizeMoveCtrl(hDlg, GetDlgItem(hDlg, update_settings_reposition_ids[i]), 0, -dy, 0, 0, 1.0f);
+			// Mica checkbox sits below the existing reposition list, so move
+			// it up by the same dy to stay aligned with the Settings group
+			ResizeMoveCtrl(hDlg, GetDlgItem(hDlg, IDC_ENABLE_MICA), 0, -dy, 0, 0, 1.0f);
 		}
 		break;
 	case WM_COMMAND:
@@ -1657,6 +1664,12 @@ INT_PTR CALLBACK UpdateCallback(HWND hDlg, UINT message, WPARAM wParam, LPARAM l
 			if (HIWORD(wParam) != CBN_SELCHANGE)
 				break;
 			WriteSettingBool(SETTING_INCLUDE_BETAS, ComboBox_GetCurSel(hBeta) == 0);
+			return (INT_PTR)TRUE;
+		case IDC_ENABLE_MICA:
+			if (HIWORD(wParam) != BN_CLICKED)
+				break;
+			WriteSetting32(SETTING_MICA,
+				(IsDlgButtonChecked(hDlg, IDC_ENABLE_MICA) == BST_CHECKED) ? 1 : 0);
 			return (INT_PTR)TRUE;
 		}
 		break;

--- a/src/ui.c
+++ b/src/ui.c
@@ -599,6 +599,11 @@ void ToggleAdvancedDeviceOptions(BOOL enable)
 	TBBUTTONINFO button_info;
 	int i, shift = advanced_device_section_height;
 
+	// Freeze redraw across all reposition/show-hide/resize calls so the user
+	// only sees the final state instead of intermediate frames; this is what
+	// removes the Mica chroma-key black flash during expand/collapse
+	SetWindowRedraw(hMainDialog, FALSE);
+
 	if (!enable)
 		shift = -shift;
 	section_vpos[1] += shift;
@@ -634,8 +639,8 @@ void ToggleAdvancedDeviceOptions(BOOL enable)
 	// Resize the main dialog and log window
 	ResizeDialogs(shift);
 
-	// Never hurts to force Windows' hand
-	InvalidateRect(hMainDialog, NULL, TRUE);
+	SetWindowRedraw(hMainDialog, TRUE);
+	RedrawWindow(hMainDialog, NULL, NULL, RDW_INVALIDATE | RDW_ERASE | RDW_ALLCHILDREN | RDW_UPDATENOW);
 }
 
 void ToggleAdvancedFormatOptions(BOOL enable)
@@ -644,6 +649,8 @@ void ToggleAdvancedFormatOptions(BOOL enable)
 	SIZE sz;
 	TBBUTTONINFO button_info;
 	int i, shift = advanced_format_section_height;
+
+	SetWindowRedraw(hMainDialog, FALSE);
 
 	if (!enable)
 		shift = -shift;
@@ -674,8 +681,8 @@ void ToggleAdvancedFormatOptions(BOOL enable)
 	// Resize the main dialog and log window
 	ResizeDialogs(shift);
 
-	// Never hurts to force Windows' hand
-	InvalidateRect(hMainDialog, NULL, TRUE);
+	SetWindowRedraw(hMainDialog, TRUE);
+	RedrawWindow(hMainDialog, NULL, NULL, RDW_INVALIDATE | RDW_ERASE | RDW_ALLCHILDREN | RDW_UPDATENOW);
 }
 
 // Toggle the display of persistence unit dropdown and resize the size field

--- a/src/ui.h
+++ b/src/ui.h
@@ -46,13 +46,16 @@
 #define DARKMODE_NORMAL_CONTROL_EDGE_COLOR			RGB(0x64, 0x64, 0x64)
 #define DARKMODE_HOT_CONTROL_EDGE_COLOR				RGB(0x9B, 0x9B, 0x9B)
 
-// Toolbar default style
+// Toolbar default style. TBSTYLE_TRANSPARENT lets the parent paint the
+// toolbar background, which is required for the Mica chroma-key compositor
+// to show through; without Mica it falls back to COLOR_3DFACE, matching the
+// previous appearance.
 #define TOOLBAR_STYLE						( WS_CHILD | WS_TABSTOP | WS_VISIBLE | \
 											  WS_CLIPSIBLINGS | WS_CLIPCHILDREN  | \
 											  CCS_NOPARENTALIGN | CCS_NODIVIDER  | \
 											  TBSTYLE_FLAT | TBSTYLE_BUTTON      | \
 											  TBSTYLE_AUTOSIZE | TBSTYLE_LIST    | \
-											  TBSTYLE_TOOLTIPS )
+											  TBSTYLE_TRANSPARENT | TBSTYLE_TOOLTIPS )
 
 // Types of update progress we report
 enum update_progress_type {


### PR DESCRIPTION
## Summary

Adds an opt-in Mica system backdrop for Rufus dialogs on Windows 11 22H2+ (build 22621), reusing the existing delay-loaded `dwmapi` rather than pulling in the Windows App SDK / WinRT `MicaController`.

- **Title bar Mica** for every dialog via `DwmSetWindowAttribute` (`DWMWA_SYSTEMBACKDROP_TYPE = DWMSBT_MAINWINDOW`).
- **Client-area Mica (dark mode only)** via `DwmExtendFrameIntoClientArea` with a subclass that paints the background transparent through DWM's compositor (`BeginBufferedPaint` + `BufferedPaintSetAlpha`). Restricted to dark mode because GDI's dark text is unreadable on the chroma-keyed light-mode backdrop.
- **Transparent toolbars** so they blend with the backdrop instead of painting a solid strip.
- **Flicker-free expand/collapse** of the advanced sections via a redraw freeze around the resize.
- **Opt-in only**: disabled by default. Toggle via the new checkbox in the Update Policy & Settings dialog (`Ctrl+Alt+M` shortcut also works). Takes effect after a restart.

The feature is fully gated: on anything below Windows 11 22H2, or with the
setting off, behaviour is unchanged.

<img width="1728" height="1160" alt="image" src="https://github.com/user-attachments/assets/793faa41-6d32-4ecf-9008-6974f604c822" />
<img width="662" height="439" alt="image" src="https://github.com/user-attachments/assets/9ddafc79-0b57-46ff-ba49-11d227bd31f7" />
<img width="660" height="434" alt="image" src="https://github.com/user-attachments/assets/5aed3e37-44d1-41e8-b085-9dc4d4cf76d2" />



## Test plan

- [x] Win11 22H2+ dark mode: enable Mica, confirm title bar + client area show the backdrop
- [x] Win11 22H2+ light mode: enable Mica, confirm only the title bar gets Mica and all labels stay readable
- [x] Expand/collapse advanced device & format sections: no flicker, log window does not pop up
- [x] Toggle the setting checkbox and `Ctrl+Alt+M`: both write the registry key and apply after restart
- [x] Win10 / Win11 21H2: confirm no behavioural change (feature unavailable, checkbox disabled)
- [x] Mica off (default): dialogs render exactly as before