### PR TITLE
Make Raw Image Remount Deterministic

### DIFF
--- a/src/format.c
+++ b/src/format.c
@@ -1517,7 +1517,9 @@ DWORD WINAPI FormatThread(void* param)
 	}
 
 	// Unassign all drives letters
-	drive_name[0] = RemoveDriveLetters(DriveIndex, TRUE, FALSE);
+	// For raw images, keep the primary partition on the earliest prior letter
+	// so we don't steal the secondary partition's former mountpoint.
+	drive_name[0] = RemoveDriveLetters(DriveIndex, !((boot_type == BT_IMAGE) && write_as_image), FALSE);
 	if (drive_name[0] == 0) {
 		uprintf("Unable to find a drive letter to use");
 		ErrorStatus = RUFUS_ERROR(APPERR(ERROR_CANT_ASSIGN_LETTER));
@@ -2048,9 +2050,11 @@ out:
 		// to the Ubuntu ESP). So we only call the code below if there are no ESPs or
 		// if we're running a Ventoy image.
 		if ((GetEspOffset(DriveIndex) == 0) || (img_report.compression_type == BLED_COMPRESSION_VTSI)) {
-			WaitForLogical(DriveIndex, 0);
 			if (GetDrivePartitionData(SelectedDrive.DeviceNumber, fs_name, sizeof(fs_name), TRUE)) {
-				volume_name = GetLogicalName(DriveIndex, 0, TRUE, TRUE);
+				// Use the refreshed main-partition offset here rather than offset 0,
+				// which can resolve to whichever volume Windows exposes first.
+				WaitForLogical(DriveIndex, SelectedDrive.Partition[partition_index[PI_MAIN]].Offset);
+				volume_name = GetLogicalName(DriveIndex, SelectedDrive.Partition[partition_index[PI_MAIN]].Offset, TRUE, TRUE);
 				if ((volume_name != NULL) && (MountVolume(drive_name, volume_name)))
 					uprintf("Remounted %s as %c:", volume_name, toupper(drive_name[0]));
 			}


### PR DESCRIPTION
## Summary

This changes the raw-image post-write remount path so Rufus consistently remounts the primary partition instead of whichever volume Windows happens to expose first.

It also makes raw-image writes reuse the earliest previously assigned drive letter for the target disk, which avoids stealing the secondary partition's mountpoint in the common multi-partition `D:`/`E:` case.

## Problem

When writing a multi-partition raw image, the post-write mount state depended on the target disk's prior drive-letter state.

In the failure case, Rufus would reuse the last removed drive letter and then try to remount the primary partition onto a letter that already belonged to the secondary partition. The remount flow also looked up the volume with partition offset `0`, which is ambiguous and can resolve to whichever matching volume Windows exposes first.

In the end, this caused our 2 partition USB drive to only show up as D: within Windows Explorer after imaging with Rufus, which then required the user to manually correct by assigning the letter E to the second partition using the Windows 'Disk Management' tool.

## Fix

- Use the refreshed main-partition offset when waiting for and resolving the remounted logical volume.
- In raw-image mode only, reuse the first removed drive letter instead of the last removed drive letter.

This keeps the change narrow while making the remount target deterministic.

## Validation

- Verified on the CFast raw-image workflow that the recurring mount-letter collision no longer reproduces.