### PR TITLE
restore classic right click context menu as qol

### DIFF
--- a/src/wue.c
+++ b/src/wue.c
@@ -444,6 +444,8 @@ char* CreateUnattendXml(int arch, int flags)
 					"\"Set-ItemProperty -Path 'Registry::HKEY_CURRENT_USER\\Software\\Microsoft\\Windows\\CurrentVersion\\Start' "
 					"-Name 'VisiblePlaces' -Value $([convert]::FromBase64String('ztU0LVr6Q0WC8iLm6vd3PC+zZ+PeiVVDv85h83sYqTe8JIo"
 					"UDNaJQqCAbtm7okiCRIF1/g0IrkKL2jTtl7ZjlEqwvXRK+WhPi9ZDmAcdqLyGCHNSqlFDQp97J3ZYRlnU')) -Type 'Binary'\"", TRUE);
+				uprintf("• QoL: Restore classic context menu");
+				StrArrayAdd(&commands, "reg add \"HKCU\\Software\\Classes\\CLSID\\{86ca1aa0-34aa-4e8b-a509-50c905bae2a2}\\InprocServer32\" /ve /t REG_SZ /d \"\" /f", TRUE);
 			}
 			// Now that we have all the commands to run, create the FirstLogonCommands section.
 			for (order = 1; order <= (int)commands.Index; order++) {


### PR DESCRIPTION
Restore the classic right click context menu as part of the QoL enchancements.

<img width="503" height="475" alt="image" src="https://github.com/user-attachments/assets/b6e5267f-236c-4963-b55c-be13def43236" />
