### PR TITLE
cregex: fix signed-char OOB/UB in char classes and 0-byte alloc on empty pattern

### DIFF
--- a/src/cregex.h
+++ b/src/cregex.h
@@ -77,12 +77,17 @@ typedef char cregex_char_class[(UCHAR_MAX + CHAR_BIT - 1) / CHAR_BIT];
 static inline int cregex_char_class_contains(const cregex_char_class klass,
                                              int ch)
 {
-    return klass[ch / CHAR_BIT] & (1 << ch % CHAR_BIT);
+    /* ch is derived from a plain (signed on most platforms) char, so bytes
+     * >= 0x80 sign-extend to a negative int. Cast to unsigned char first or
+     * this indexes klass[] out of bounds and shifts by a negative amount. */
+    unsigned char uch = (unsigned char)ch;
+    return klass[uch / CHAR_BIT] & (1 << uch % CHAR_BIT);
 }
 
 static inline int cregex_char_class_add(cregex_char_class klass, int ch)
 {
-    klass[ch / CHAR_BIT] |= 1 << (ch % CHAR_BIT);
+    unsigned char uch = (unsigned char)ch;
+    klass[uch / CHAR_BIT] |= 1 << (uch % CHAR_BIT);
     return ch;
 }
 

--- a/src/cregex_parse.c
+++ b/src/cregex_parse.c
@@ -247,7 +247,10 @@ static cregex_node_t *parse_context(regex_parse_context *context, int depth)
 
 static inline int estimate_nodes(const char *pattern)
 {
-    return (int)strlen(pattern) * 2;
+    /* +1 so that an empty pattern ("") still gets a non-zero allocation:
+     * parse_context() always pushes at least one (EPSILON) node via
+     * concatenate(), even when nothing was parsed. */
+    return (int)strlen(pattern) * 2 + 1;
 }
 
 /* Parse a pattern (using a previously allocated buffer of at least


### PR DESCRIPTION
Found via fuzzing the cregex module.

- Fixes undefined behavior from signed-char indexing into character-class lookup tables (a char with the high bit set becomes a negative index, causing an out-of-bounds read).
- Avoids a 0-byte allocation when compiling an empty pattern.

