### PR TITLE
cregex: fix heap OOB read past pattern buffer in parse_char_class()

### DIFF
--- a/src/cregex.h
+++ b/src/cregex.h
@@ -77,12 +77,17 @@ typedef char cregex_char_class[(UCHAR_MAX + CHAR_BIT - 1) / CHAR_BIT];
 static inline int cregex_char_class_contains(const cregex_char_class klass,
                                              int ch)
 {
-    return klass[ch / CHAR_BIT] & (1 << ch % CHAR_BIT);
+    /* ch is derived from a plain (signed on most platforms) char, so bytes
+     * >= 0x80 sign-extend to a negative int. Cast to unsigned char first or
+     * this indexes klass[] out of bounds and shifts by a negative amount. */
+    unsigned char uch = (unsigned char)ch;
+    return klass[uch / CHAR_BIT] & (1 << uch % CHAR_BIT);
 }
 
 static inline int cregex_char_class_add(cregex_char_class klass, int ch)
 {
-    klass[ch / CHAR_BIT] |= 1 << (ch % CHAR_BIT);
+    unsigned char uch = (unsigned char)ch;
+    klass[uch / CHAR_BIT] |= 1 << (uch % CHAR_BIT);
     return ch;
 }
 

--- a/src/cregex_parse.c
+++ b/src/cregex_parse.c
@@ -72,11 +72,13 @@ static cregex_node_t *parse_char_class(regex_parse_context *context)
                             .type = type, .from = from, .to = context->sp - 1});
         case '\\':
             ch = *context->sp++;
+            if (ch == '\0')
+                return NULL;
             /* fall-through */
         default:
         CHARACTER:
             if (*context->sp == '-' && context->sp[1] != ']') {
-                if (context->sp[1] < ch)
+                if ((unsigned char)context->sp[1] < (unsigned char)ch)
                     /* empty range in character class */
                     return NULL;
                 context->sp += 2;

--- a/src/cregex_parse.c
+++ b/src/cregex_parse.c
@@ -247,7 +247,10 @@ static cregex_node_t *parse_context(regex_parse_context *context, int depth)
 
 static inline int estimate_nodes(const char *pattern)
 {
-    return (int)strlen(pattern) * 2;
+    /* +1 so that an empty pattern ("") still gets a non-zero allocation:
+     * parse_context() always pushes at least one (EPSILON) node via
+     * concatenate(), even when nothing was parsed. */
+    return (int)strlen(pattern) * 2 + 1;
 }
 
 /* Parse a pattern (using a previously allocated buffer of at least


### PR DESCRIPTION
Found via fuzzing the cregex module.

Fixes a heap out-of-bounds read where the "empty range" check in a character class compared a possibly negative, sign-extended char against the next byte, letting the parser advance past the end of the pattern buffer. Also rejects a dangling backslash-escape at end-of-pattern the same way an unescaped NUL already is.

Also submitted upstream to the original library: jserv/cregex#2