### PR TITLE
Show filtered USB drives as hidden hints

### DIFF
--- a/res/loc/ChangeLog.txt
+++ b/res/loc/ChangeLog.txt
@@ -11,6 +11,9 @@ o v?.??
   - *NEW*      MSG_372 "I WILL ensure that all disks, except the one I want to install Windows on, are disconnected."
   - *NEW*      MSG_373 "I WILL ensure that I don't leave this media plugged on a PC I do not plan to erase."
   - *NEW*      MSG_374 "I AGREE that any data loss resulting from the use of this option lies entirely with me."
+  // These messages identify drives hidden by the default USB hard-drive filter and explain how to enable them.
+  - *NEW*      MSG_375 "%s — %s (hidden)"
+  - *NEW*      MSG_376 "To use this drive, enable the 'List USB Hard Drives' option in Advanced drive properties."
 
 o v4.14 (2026.04.30)
   // NB: I used Google translate to update the following message, so please check for accuracy!

--- a/res/loc/rufus.loc
+++ b/res/loc/rufus.loc
@@ -641,6 +641,8 @@ t MSG_371 "If you use this option, please make sure to disconnect every disk fro
 t MSG_372 "I WILL ensure that all disks, except the one I want to install Windows on, are disconnected."
 t MSG_373 "I WILL ensure that I don't leave this media plugged on a PC I do not plan to erase."
 t MSG_374 "I AGREE that any data loss resulting from the use of this option lies entirely with me."
+t MSG_375 "%s — %s (hidden)"
+t MSG_376 "To use this drive, enable the 'List USB Hard Drives' option in Advanced drive properties."
 
 # The following messages are for the Windows Store listing only and are not used by the application
 t MSG_900 "Rufus is a utility that helps format and create bootable USB flash drives, such as USB keys/pendrives, memory sticks, etc."

--- a/src/dev.c
+++ b/src/dev.c
@@ -475,13 +475,13 @@ BOOL GetDevices(DWORD devnum)
 	const char* windows_sandbox_vhd_label = "PortableBaseLayer";
 	// Hash table and String Array used to match a Device ID with the parent hub's Device Interface Path
 	htab_table htab_devid = HTAB_EMPTY;
-	StrArray dev_if_path = { 0 };
+	StrArray dev_if_path = { 0 }, hidden_drives = { 0 };
 	char letter_name[] = " (?:)";
 	char drive_name[] = "?:\\";
 	char setting_name[32];
 	char uefi_togo_check[] = "?:\\EFI\\Rufus\\ntfs_x64.efi";
 	char scsi_card_name_copy[16];
-	BOOL r = FALSE, found = FALSE, post_backslash;
+	BOOL r = FALSE, found = FALSE, post_backslash, hide_drive;
 	HDEVINFO dev_info = NULL;
 	SP_DEVINFO_DATA dev_info_data;
 	SP_DEVICE_INTERFACE_DATA devint_data;
@@ -502,6 +502,7 @@ BOOL GetDevices(DWORD devnum)
 	IGNORE_RETVAL(ComboBox_ResetContent(hDeviceList));
 	ClearDrives();
 	StrArrayCreate(&dev_if_path, 128);
+	StrArrayCreate(&hidden_drives, 8);
 	// Add a dummy for string index zero, as this is what non matching hashes will point to
 	StrArrayAdd(&dev_if_path, "", TRUE);
 
@@ -858,6 +859,7 @@ BOOL GetDevices(DWORD devnum)
 		devint_detail_data = NULL;
 		for (j = 0; ; j++) {
 			safe_free(devint_detail_data);
+			hide_drive = FALSE;
 
 			if (!SetupDiEnumDeviceInterfaces(dev_info, &dev_info_data, &GUID_DEVINTERFACE_DISK, j, &devint_data)) {
 				if(GetLastError() != ERROR_NO_MORE_ITEMS) {
@@ -940,19 +942,18 @@ BOOL GetDevices(DWORD devnum)
 				}
 				if ((!enable_HDDs) && (!props.is_VHD) && (!props.is_CARD) &&
 					((score = IsHDD(drive_index, (uint16_t)props.vid, (uint16_t)props.pid, buffer)) > 0)) {
-					uprintf("Device eliminated because it was detected as a Hard Drive or SSD (score %d > 0)", score);
+					uprintf("Device hidden because it was detected as a Hard Drive or SSD (score %d > 0)", score);
 					if (!list_non_usb_removable_drives)
 						uprintf("If this device is not a Hard Drive or SSD, please e-mail the author of this application");
 					uprintf("NOTE: You can enable the listing of Hard Drives under 'advanced drive properties'");
-					safe_free(devint_detail_data);
-					break;
+					hide_drive = TRUE;
 				} else if ((!enable_HDDs) && (props.is_CARD) && (drive_size > MAX_DEFAULT_LIST_CARD_SIZE)) {
-					uprintf("Device eliminated because it was detected as a card larger than %s",
+					uprintf("Device hidden because it was detected as a card larger than %s",
 						SizeToHumanReadable(MAX_DEFAULT_LIST_CARD_SIZE, FALSE, FALSE));
 					uprintf("To use such a card, check 'List USB Hard Drives' under 'advanced drive properties'");
-					safe_free(devint_detail_data);
-					break;
-				} else if (props.is_VHD && IsMsDevDrive(drive_index)) {
+					hide_drive = TRUE;
+				}
+				if (props.is_VHD && IsMsDevDrive(drive_index)) {
 					uprintf("Device eliminated because it was detected as a Microsoft Dev Drive");
 					safe_free(devint_detail_data);
 					break;
@@ -1019,6 +1020,13 @@ BOOL GetDevices(DWORD devnum)
 						SizeToHumanReadable(drive_size, FALSE, use_fake_units));
 					display_name = display_msg;
 				}
+				if (hide_drive) {
+					static_sprintf(str, "%s", display_name);
+					static_sprintf(buffer, "%s", lmprintf(MSG_375, buffer, str));
+					StrArrayAdd(&hidden_drives, buffer, TRUE);
+					safe_free(devint_detail_data);
+					break;
+				}
 
 				rufus_drive[num_drives].index = drive_index;
 				rufus_drive[num_drives].id = safe_strdup(device_instance_id);
@@ -1066,7 +1074,14 @@ BOOL GetDevices(DWORD devnum)
 		IGNORE_RETVAL(ComboBox_SetItemData(hDeviceList, ComboBox_AddStringU(hDeviceList, rufus_drive[u].display_name), rufus_drive[u].index));
 		maxwidth = max(maxwidth, GetEntryWidth(hDeviceList, rufus_drive[u].display_name));
 	}
-	// Adjust the Dropdown width to the maximum text size
+	// Add informational rows for devices that require the explicit HDD opt-in.
+	for (u = 0; u < (int)hidden_drives.Index; u++) {
+		IGNORE_RETVAL(ComboBox_SetItemData(hDeviceList,
+			ComboBox_AddStringU(hDeviceList, hidden_drives.String[u]), 0));
+		maxwidth = max(maxwidth, GetEntryWidth(hDeviceList, hidden_drives.String[u]));
+	}
+	// Adjust the Dropdown width to the maximum text size, plus room for borders and a scrollbar
+	maxwidth += GetSystemMetrics(SM_CXVSCROLL) + GetSystemMetrics(SM_CXEDGE) * 4 + 8;
 	SendMessage(hDeviceList, CB_SETDROPPEDWIDTH, (WPARAM)maxwidth, 0);
 
 	if (devnum >= DRIVE_INDEX_MIN) {
@@ -1078,7 +1093,7 @@ BOOL GetDevices(DWORD devnum)
 		}
 	}
 	if (!found)
-		i = 0;
+		i = (num_drives == 0) ? CB_ERR : 0;
 	IGNORE_RETVAL(ComboBox_SetCurSel(hDeviceList, i));
 	SendMessage(hMainDialog, WM_COMMAND, (CBN_SELCHANGE<<16) | IDC_DEVICE, 0);
 	r = TRUE;
@@ -1088,6 +1103,7 @@ out:
 	SendMessage(hMainDialog, WM_NEXTDLGCTL, (WPARAM)GetDlgItem(hMainDialog, IDC_START), TRUE);
 	safe_free(devid_list);
 	StrArrayDestroy(&dev_if_path);
+	StrArrayDestroy(&hidden_drives);
 	htab_destroy(&htab_devid);
 	return r;
 }

--- a/src/rufus.c
+++ b/src/rufus.c
@@ -901,6 +901,27 @@ void EnableControls(BOOL enable, BOOL remove_checkboxes)
 
 // Populate the UI main dropdown properties.
 // This should be called on device or boot type change.
+static BOOL IsSelectableDevice(int combo_index)
+{
+	DWORD drive_index;
+
+	if ((combo_index < 0) || (combo_index >= ComboBox_GetCount(hDeviceList)))
+		return FALSE;
+	drive_index = (DWORD)ComboBox_GetItemData(hDeviceList, combo_index);
+	return (drive_index >= DRIVE_INDEX_MIN) && (drive_index < DRIVE_INDEX_MAX);
+}
+
+static int GetSelectableDeviceCount(void)
+{
+	int i, count = 0;
+
+	for (i = 0; i < ComboBox_GetCount(hDeviceList); i++) {
+		if (IsSelectableDevice(i))
+			count++;
+	}
+	return count;
+}
+
 static BOOL PopulateProperties(void)
 {
 	char* device_tooltip;
@@ -2482,7 +2503,27 @@ static INT_PTR CALLBACK MainCallback(HWND hDlg, UINT message, WPARAM wParam, LPA
 		case IDC_DEVICE:
 			if (HIWORD(wParam) != CBN_SELCHANGE)
 				break;
-			nb_devices = ComboBox_GetCount(hDeviceList);
+			nDeviceIndex = ComboBox_GetCurSel(hDeviceList);
+			if ((nDeviceIndex != CB_ERR) && !IsSelectableDevice(nDeviceIndex)) {
+				for (i = 0; i < ComboBox_GetCount(hDeviceList); i++) {
+					if (IsSelectableDevice(i) &&
+						((DWORD)ComboBox_GetItemData(hDeviceList, i) == DeviceNum))
+						break;
+				}
+				IGNORE_RETVAL(ComboBox_SetCurSel(hDeviceList,
+					(i < ComboBox_GetCount(hDeviceList)) ? i : CB_ERR));
+				ComboBox_ShowDropdown(hDeviceList, FALSE);
+				if (!advanced_mode_device) {
+					CheckDlgButton(hMainDialog, IDC_ADVANCED_DRIVE_PROPERTIES, BST_CHECKED);
+					SendMessage(hMainDialog, WM_COMMAND,
+						(BN_CLICKED << 16) | IDC_ADVANCED_DRIVE_PROPERTIES, 0);
+				}
+				Notification(MB_OK | MB_ICONINFORMATION, APPLICATION_NAME, lmprintf(MSG_376));
+				SendMessage(hMainDialog, WM_NEXTDLGCTL,
+					(WPARAM)GetDlgItem(hMainDialog, IDC_LIST_USB_HDD), TRUE);
+				break;
+			}
+			nb_devices = GetSelectableDeviceCount();
 			PrintStatusDebug(0, (nb_devices == 1) ? MSG_208 : MSG_209, nb_devices);
 			PopulateProperties();
 			nDeviceIndex = ComboBox_GetCurSel(hDeviceList);
@@ -3161,7 +3202,7 @@ static INT_PTR CALLBACK MainCallback(HWND hDlg, UINT message, WPARAM wParam, LPA
 		if (queued_hotplug_event)
 			SendMessage(hDlg, UM_MEDIA_CHANGE, 0, 0);
 		if (wParam == BOOTCHECK_CANCEL) {
-			nb_devices = ComboBox_GetCount(hDeviceList);
+			nb_devices = GetSelectableDeviceCount();
 			PrintStatus(0, (nb_devices == 1) ? MSG_208 : MSG_209, nb_devices);
 			PrintStatus(5000, MSG_041);
 			if (unattend_xml_path != NULL) {


### PR DESCRIPTION
## Summary

- Keep USB HDD/SSD and large-card candidates hidden by the default hard-drive filter visible as informational device rows suffixed with `(hidden)`.
- Show Rufus's native information dialog when a hidden row is activated, explaining how to enable `List USB Hard Drives` under Advanced drive properties.
- Preserve the existing explicit opt-in and all hard safety exclusions.

## Safety

- Informational rows use sentinel item data and are appended after real drives, preserving the combo-index-to-drive-array mapping.
- A hidden selection restores the previous real target (or no selection) before the dropdown closes and before the modal opens.
- Hidden rows cannot reach `PopulateProperties`, process search, or formatting paths.
- Microsoft Dev Drives, explicitly filtered drives, Windows Sandbox/Bitdefender VHDs, the system disk, and the disk hosting Rufus remain excluded.

## Validation

- Debug x64 build with MSVC v143 override: passed.
- Release x64 build with MSVC v143 override: passed.
- `git diff --check`: passed.